### PR TITLE
Tidy-imports-and-review-runtime-requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/maxfordham/ipyautoui/HEAD)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![PyPI version](https://badge.fury.io/py/ipyautoui.svg)](https://badge.fury.io/py/ipyautoui)
 
 ![](docs/logo.png)
 
-## Try in online! 
+## Try in online!
 
 launch [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/maxfordham/ipyautoui/HEAD).
 
@@ -16,24 +17,22 @@ launch [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/
 in future versions.
 ```
 
-```
-# TODO: do this! WARNING ipyautoui is WIP is not yet packaged and distrubuted 
-#       so the commands below don't work.
-
-mamba install ipyautoui -c conda-forge  # mamba ...
-conda install ipyautoui -c conda-forge  # or conda ...
-pip install ipyautoui  # or pip ...
+```sh
+pip install ipyautoui
+mamba install ipyautoui -c conda-forge  # mamba ... TODO: add to conda-forge. 
+conda install ipyautoui -c conda-forge  # or conda ... TODO: add to conda-forge. 
 ```
 
 ## Intro
 
-A high-level wrapper library that sits on top of [__ipywidgets__](https://github.com/jupyter-widgets/ipywidgets) (and other ipy- widget libraries), [__pydantic__](https://github.com/samuelcolvin/pydantic/) 
+A high-level wrapper library that sits on top of [__ipywidgets__](https://github.com/jupyter-widgets/ipywidgets) (and other ipy- widget libraries), [__pydantic__](https://github.com/samuelcolvin/pydantic/)
 and Jupyter rich display system to template and automate the creation of widget forms / user-interfaces. The core user-facing classes in this library are __AutoUi__, __AutoVjsf__ and __AutoDisplay__:
 
 ```python
 from ipyautoui import AutoUi, AutoVjsf, AutoDisplay
 ```
-ipyautoui aims to give you as much as possible out-the-box, whilst also supporting a simple workflow to extend and customise the interface to specific user requirements. 
+
+ipyautoui aims to give you as much as possible out-the-box, whilst also supporting a simple workflow to extend and customise the interface to specific user requirements.
 
 ## Summary of main features
 
@@ -45,17 +44,20 @@ from ipyautoui import AutoUi
 
 class LineGraph(BaseModel):
     """parameters to define a simple `y=m*x + c` line graph"""
-    title: str = Field(default='line equation', description='add chart title here')
+    title: str = Field(default='line equation', description='add chart title')
     m: float = Field(default=2, description='gradient')
-    c: float = Field(default=5, description='intercept')
-    x_range: tuple[int, int] = Field(default=(0,5), ge=0, le=50, description='x-range for chart')
-    y_range: tuple[int, int] = Field(default=(0,5), ge=0, le=50, description='y-range for chart')
+    c: float = Field(default=5, ge=0, le=10, description='intercept')
+    x_range: tuple[int, int] = Field(
+        default=(0,5), ge=0, le=50, description='x-range for chart')
+    y_range: tuple[int, int] = Field(
+        default=(0,5), ge=0, le=50, description='y-range for chart')
     
 lg = LineGraph()
 ui = AutoUi(schema=lg)
 ui
 ```
-![](images/autoui-linegraph.png)
+
+![autoui-linegraph](images/autoui-linegraph.png)
 
 ```python
 
@@ -110,8 +112,7 @@ The main benefit of AutoUi (and main the reason for continuing to develop it), i
   - TODO: where the datasource is not a file, the extension is a mapping code that maps a renderer to the datastructure of the data. 
 - Custom renderer's can be passed to `AutoDisplay` allowing it to display user-defined filetypes (or compound extension filetypes)
 
-
-## How it works:
+## How it works
 
 - Make a pydantic model (or json schema) that defines the UI
 - Pass the model to `AutoUi` or `AutoVjsf` to generate an user-interface
@@ -132,6 +133,7 @@ This package intends to be high-level, and unifies many other ipy- libraries und
 - [Plotly](https://github.com/plotly/plotly.py) (for viewing `.plotly.json` files. note. this needs to be added by the user)
 
 It is also obviously wholly dependent on the excellent json-schema specification:
+
 - [json-schema](https://json-schema.org/)
 
 ## Development installation
@@ -146,6 +148,15 @@ $ mamba env create -f environment-dev.yml
 # run tests
 $ pytest
 ```
+
+## Packaging (restricted to core-maintainers)
+
+```sh
+hatch build  # builds to local folder
+hatch publish  # publishes to pypi
+
+```
+
 
 ## Contributions
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,7 +7,7 @@ channels:
   - conda-forge
 #  - http://10.10.30.125:8000
 dependencies:
-  - python>=3.7,<3.10
+  - python>=3.7
   - numpy
   - pandas
   - jupyterlab>=3.0.14
@@ -26,7 +26,6 @@ dependencies:
   - altair
   - pydantic
   - dacite
-  - xmltodict
   - pyyaml
   - openpyxl
   - black

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,10 +12,9 @@ channels:
   - conda-forge
 #  - http://10.10.30.125:8000
 dependencies:
-  - python>=3.7,<3.10
+  - python>=3.7
   - numpy
   - pandas
-  - matplotlib
   - jupyterlab>=3.0.14
   - xeus-python
   - ipywidgets
@@ -23,8 +22,6 @@ dependencies:
   - ipyfilechooser
   - ipydatagrid
   - ipyvuetify
-  - ipyvue
-#  - ipyrun>=v0.1.9
   - voila>=0.2.11
   - plotly
   - halo
@@ -34,7 +31,6 @@ dependencies:
   - altair
   - pydantic
   - dacite
-  - xmltodict
   - pyyaml
   - pillow
 #  - click

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ channels:
   - conda-forge
 #  - http://10.10.30.125:8000
 dependencies:
-  - python>=3.7,<3.10
+  - python>=3.7
   - numpy
   - pandas
   - jupyterlab>=3.0.14
@@ -26,8 +26,6 @@ dependencies:
   - nodejs
   - altair
   - pydantic
-  - dacite
-  - xmltodict
   - pyyaml
   - openpyxl
   - black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,19 +24,15 @@ dependencies = [
     "ipyvuetify",      # make optional
     "Markdown",
     "numpy",
-    "openpyxl",
+    "openpyxl",        # for excel fiel viewer
     "pandas",
     "pydantic",
     "pytest",
     "PyYAML",
-    "requests",
-    "setuptools",
     "stringcase",
     "traitlets",
     "traitlets_paths",
     "wcmatch",
-    "xmltodict",
-    "seedir",
 ]
 
 [project.urls]

--- a/src/ipyautoui/__init__.py
+++ b/src/ipyautoui/__init__.py
@@ -18,10 +18,10 @@ Example::
     DISPLAY_AUTOUI_SCHEMA_EXAMPLE()
     
 """
-import pathlib
-import sys
+# import pathlib
+# import sys
 
-sys.path.append(str(pathlib.Path(__file__).parents[1]))
+# sys.path.append(str(pathlib.Path(__file__).parents[1]))
 # #  ^ for dev only. TODO: comment out at build time
 
 from ipyautoui.autoui import AutoUi

--- a/src/ipyautoui/autodisplay.py
+++ b/src/ipyautoui/autodisplay.py
@@ -45,7 +45,7 @@ from IPython.display import (
     display,
     clear_output,
     Markdown,
-)  # , Image JSON, HTML, IFrame,
+)
 import time
 import typing as ty
 import ipywidgets as w

--- a/src/ipyautoui/autodisplay.py
+++ b/src/ipyautoui/autodisplay.py
@@ -36,7 +36,7 @@ Example:
 """
 # %run __init__.py
 # %load_ext lab_black
-# TODO: update displayfile_definitions based on the extra work done...
+
 # +
 import pathlib
 import functools
@@ -610,7 +610,6 @@ class AutoDisplay(tr.HasTraits):
 # TODO: render markdown to html using pandoc and rebase relative paths - https://github.com/jgm/pandoc/issues/3752
 # TODO: render Vega updating the data path
 # TODO: render pdf update the relative path
-# TODO: figure out why the spacing between rows is weird
 
 if __name__ == "__main__":
     from ipyautoui.test_schema import TestAutoLogic

--- a/src/ipyautoui/autodisplayfile_renderers.py
+++ b/src/ipyautoui/autodisplayfile_renderers.py
@@ -40,11 +40,10 @@ Example:
 import os
 import pathlib
 import pandas as pd
-from IPython.display import display, Markdown, IFrame, clear_output, Image, HTML
+from IPython.display import display, Markdown, IFrame, clear_output, HTML
 import json
 import ipydatagrid as ipg
 import ipywidgets as w
-import importlib.util
 import traitlets as tr
 import traitlets_paths
 

--- a/src/ipyautoui/autodisplayfile_renderers.py
+++ b/src/ipyautoui/autodisplayfile_renderers.py
@@ -367,12 +367,12 @@ DEFAULT_FILE_RENDERERS = frozenmap(
         ".gif": preview_image,
         ".mp4": preview_video,
         ".mp3": preview_audio,
-        #'.obj': obj_prev, # add ipyvolume viewer?
+        #'.obj': obj_prev, # TODO: add ipyvolume viewer?
         ".txt": preview_text,
         ".bat": preview_text,
         ".rst": preview_text,
         "": preview_text_or_dir,
-        ".toml": preview_text,  # TODO: add toml viewer?
+        ".toml": preview_text,
         ".md": preview_markdown,
         ".py": PreviewPython,
         ".pdf": preview_pdf,

--- a/src/ipyautoui/autoipywidget.py
+++ b/src/ipyautoui/autoipywidget.py
@@ -34,9 +34,6 @@ import functools
 import ipywidgets as w
 from IPython.display import display
 import traitlets as tr
-
-# TODO: Tasks pending completion -@jovyan at 7/18/2022, 2:07:55 PM
-# use traitlets_paths or not... pull request to main traitlets?
 import typing as ty
 import inspect
 import json
@@ -420,7 +417,7 @@ class AutoObject(AutoObjectFormLayout):  # w.VBox
                         "if you want to use order to hide rows then set:"
                         "`order_hides_rows = True`"
                     )
-        # TODO: order not updating
+        # BUG: order not updating
         return v
 
     @tr.validate("order_can_hide_rows")

--- a/src/ipyautoui/autoipywidget.py
+++ b/src/ipyautoui/autoipywidget.py
@@ -38,19 +38,14 @@ import traitlets as tr
 # TODO: Tasks pending completion -@jovyan at 7/18/2022, 2:07:55 PM
 # use traitlets_paths or not... pull request to main traitlets?
 import typing as ty
-from ipyautoui.constants import DOWNARROW_BUTTON_KWARGS
-from ipyautoui.custom.showhide import ShowHide
-import ipyautoui.automapschema as aumap
-import immutables
 import inspect
-from ipyautoui._utils import obj_from_importstr
 import json
+from IPython.display import display, clear_output
+import ipyautoui.automapschema as aumap
 from ipyautoui.constants import BUTTON_WIDTH_MIN
-from IPython.display import display, Markdown, clear_output, display_pretty
-from ipyautoui._utils import display_python_string
-from ipyautoui.custom.save_buttonbar import SaveButtonBar, SaveActions
-
-frozenmap = immutables.Map
+from ipyautoui._utils import display_python_string, obj_from_importstr
+from ipyautoui.custom.save_buttonbar import SaveButtonBar
+from ipyautoui.custom.showhide import ShowHide
 
 
 # +

--- a/src/ipyautoui/automapschema.py
+++ b/src/ipyautoui/automapschema.py
@@ -655,7 +655,6 @@ def map_widget(di, widgets_map=None, fail_on_error=False) -> WidgetCaller:
 
     if len(mapped) == 0:
         if fail_on_error:
-            # TODO: pass error or not..
             raise ValueError(f"widget map not found for: {di}")
         else:
             return WidgetCaller(schema_=di, autoui=auiwidgets.AutoPlaceholder)
@@ -665,7 +664,6 @@ def map_widget(di, widgets_map=None, fail_on_error=False) -> WidgetCaller:
         w = get_widget(di, k, widgets_map)
         return WidgetCaller(schema_=di, autoui=w)
     else:
-        # TODO: add logging. take last map
         print(f"{di['title']}. multiple matches found. using the last one.")
         print(mapped)
         k = mapped[-1]

--- a/src/ipyautoui/autoui.py
+++ b/src/ipyautoui/autoui.py
@@ -29,26 +29,19 @@ Example:
 """
 # %run __init__.py
 # #%load_ext lab_black
-import logging
+
 import pathlib
-import functools
-import ipywidgets as w
-from IPython.display import display, Markdown, clear_output, display_pretty
-from pydantic import BaseModel, Field
-from markdown import markdown
-import immutables
+from IPython.display import display
+from pydantic import BaseModel
 import json
 import traitlets as tr
 import traitlets_paths
 import typing as ty
-from enum import Enum
 
-from ipyautoui._utils import display_python_string
-from ipyautoui.custom import SaveButtonBar  #  Grid, FileChooser,
-from ipyautoui.constants import BUTTON_WIDTH_MIN
+from ipyautoui.custom import (
+    SaveButtonBar,
+)  # NOTE: removing this unused import creates circular import errors
 from ipyautoui.autoipywidget import AutoObject, get_from_schema_root
-
-# from ipyautoui.autovjsf import AutoVjsf
 
 
 # +

--- a/src/ipyautoui/autovjsf.py
+++ b/src/ipyautoui/autovjsf.py
@@ -90,10 +90,6 @@ class AutoVjsf(AutoObjectFormLayout, AutoUiFileMethods, AutoRenderMethods):
         self._init_vui_form()
         self._init_controls()
 
-        # self.save_buttonbar._unsaved_changes(
-        #     False
-        # )  # TODO: not sure why this is required
-
     def get_description(self):  # TODO: put this in AutoObjectFormLayout
         return get_from_schema_root(self.schema, "description")
 
@@ -135,7 +131,7 @@ class AutoVjsf(AutoObjectFormLayout, AutoUiFileMethods, AutoRenderMethods):
         self._value = self.vui.value
 
     @property
-    def schema(self):  # TODO: change to schema
+    def schema(self):
         return self.vui.schema
 
 

--- a/src/ipyautoui/autowidgets.py
+++ b/src/ipyautoui/autowidgets.py
@@ -25,8 +25,7 @@ from ipyautoui.constants import MAP_JSONSCHEMA_TO_IPYWIDGET
 import ipywidgets as w
 import traitlets as tr
 from copy import deepcopy
-from ipyautoui._utils import obj_from_importstr
-from ipyautoui.custom import modelrun, markdown_widget, editgrid, filechooser
+from ipyautoui.custom import modelrun, markdown_widget, filechooser
 from ipyautoui._utils import remove_non_present_kwargs
 from datetime import datetime
 

--- a/src/ipyautoui/constants.py
+++ b/src/ipyautoui/constants.py
@@ -1,12 +1,12 @@
 """contains packages global constants"""
 import pathlib
-
-from ipydatagrid import TextRenderer, Expr, VegaExpr
+from ipydatagrid import TextRenderer
 from ipyautoui._utils import frozenmap
 
+# ^ frozenmap
 # https://www.python.org/dev/peps/pep-0603/
 # https://github.com/MagicStack/immutables
-# ^
+
 DIR_MODULE = pathlib.Path(__file__).parent
 DIR_EXAMPLE = DIR_MODULE.parents[1] / "examples"
 PATH_VJSF_TEMPLATE = DIR_MODULE / "vjsf.vue"
@@ -92,7 +92,8 @@ DELETE_BUTTON_KWARGS = frozenmap(
 
 KWARGS_DATAGRID_DEFAULT = frozenmap(
     header_renderer=TextRenderer(
-        vertical_alignment="top", horizontal_alignment="center",
+        vertical_alignment="top",
+        horizontal_alignment="center",
     )
 )
 
@@ -109,13 +110,13 @@ KWARGS_OPENFILE = frozenmap(
     icon="file",
     layout={"width": BUTTON_WIDTH_MIN, "height": BUTTON_HEIGHT_MIN},
     tooltip="open file with system software",
-    style={"font_weight": "bold" } #, "button_color": OPEN_BN_COLOR},
+    style={"font_weight": "bold"},  # , "button_color": OPEN_BN_COLOR},
 )
 KWARGS_OPENFOLDER = frozenmap(
     icon="folder",
     layout={"width": BUTTON_WIDTH_MIN, "height": BUTTON_HEIGHT_MIN},
     tooltip="open folder in file-browser",
-    style={"font_weight": "bold"} #, "button_color": OPEN_BN_COLOR},
+    style={"font_weight": "bold"},  # , "button_color": OPEN_BN_COLOR},
 )
 
 KWARGS_DISPLAY = frozenmap(

--- a/src/ipyautoui/custom/__init__.py
+++ b/src/ipyautoui/custom/__init__.py
@@ -1,16 +1,13 @@
-import sys
-import pathlib
+# import sys
+# import pathlib
 
-sys.path.append(str(pathlib.Path(__file__).parents[2]))
+# sys.path.append(str(pathlib.Path(__file__).parents[2]))
 # ^ for dev only. TODO: comment out at build time
 
 from ipyautoui.custom.filechooser import FileChooser
 from ipyautoui.custom.multiselect_search import MultiSelectSearch
 from ipyautoui.custom.iterable import Array, Dictionary
-
-# from ipyautoui.custom.modelrun import RunName
 from ipyautoui.custom.loadproject import LoadProject
 from ipyautoui.custom.save_buttonbar import SaveButtonBar
 
 # from ipyautoui.custom.edit_menu import EditGrid  # TODO: make this work
-

--- a/src/ipyautoui/custom/decision_branch.py
+++ b/src/ipyautoui/custom/decision_branch.py
@@ -19,13 +19,9 @@
 """
 a UI element that loads a folder for data caching, whilst storing a record of folders in use
 """
-from __future__ import annotations
 
 # %run __init__.py
 # %load_ext lab_black
-
-
-from enum import Enum
 from pydantic import BaseModel
 import ipywidgets as w
 import typing as ty

--- a/src/ipyautoui/custom/editgrid.py
+++ b/src/ipyautoui/custom/editgrid.py
@@ -22,11 +22,7 @@
 # %load_ext lab_black
 import traitlets as tr
 import typing as ty
-import collections
 import traceback
-import functools
-
-import immutables
 import pandas as pd
 import ipywidgets as w
 from typing import List
@@ -37,27 +33,9 @@ from ipydatagrid.datagrid import SelectionHelper
 import ipyautoui.autoipywidget as aui
 import ipyautoui.custom.save_buttonbar as sb
 from ipyautoui._utils import obj_from_importstr
-from ipyautoui.automapschema import attach_schema_refs
-from ipyautoui._utils_debounce import debounce
 import logging
 
-frozenmap = immutables.Map
-
-# TODO: Tasks pending completion -@jovyan at 9/14/2022, 5:09:18 PM
-#       review how ipydatagrid works. it has a _data trait which has
-#       a schema. Perhaps we can make better use of this / contribute
-#       back to the main repo.
-
-# BUG: Reported defects -@jovyan at 9/16/2022, 5:25:13 PM
-#      the selection when filtered issue is creating a problem.
-
-# TODO: Tasks pending completion -@jovyan at 9/22/2022, 9:25:53 PM
-#       Can BaseForm inherit autoipywidget.AutoObject directly?
-
-# TODO: give ButtonBar its own module
-
 # TODO: rename "add" to "fn_add" so not ambiguous...
-
 
 # +
 def is_incremental(li):

--- a/src/ipyautoui/custom/filechooser.py
+++ b/src/ipyautoui/custom/filechooser.py
@@ -18,7 +18,7 @@
 # %load_ext lab_black
 
 import pathlib
-from traitlets import HasTraits, default, validate, Unicode
+import traitlets as tr
 from traitlets_paths import PurePath  # TODO: create conda recipe for this package
 from ipyfilechooser import FileChooser
 
@@ -41,13 +41,9 @@ class FileChooser(FileChooser):
     """
 
     # _value = PurePath()
-    _value = Unicode()
+    _value = tr.Unicode()
 
-    # @validate("_value")
-    # def _valid_value(self, proposal):
-    #     return make_path(proposal["value"])
-
-    @default("_value")
+    @tr.default("_value")
     def _default_value(self):
         return str(pathlib.Path("."))
 
@@ -127,5 +123,3 @@ if __name__ == "__main__":
 
 if __name__ == "__main__":
     display(ui.value)
-
-

--- a/src/ipyautoui/custom/filesindir.py
+++ b/src/ipyautoui/custom/filesindir.py
@@ -20,16 +20,10 @@
 # +
 import pathlib
 from wcmatch.pathlib import Path as wcPath
-from traitlets_paths import PurePath  # TODO: create conda recipe for this package
 import ipywidgets as w
 import traitlets as tr
-from traitlets import HasTraits, default, validate
 from typing import List
-import immutables
-import inspect
 import functools
-
-# from pydantic.dataclasses import dataclass
 from ipyautoui.basemodel import BaseModel
 from pydantic import validator, Field
 
@@ -43,7 +37,7 @@ from ipyautoui.constants import (
 )
 
 # +
-patherns_des = """
+PATTERNS_DES = """
 list of glob pattern match strings that will be searched within fdir
 ref: https://facelessuser.github.io/wcmatch/pathlib/
 """
@@ -54,7 +48,7 @@ class FilesInDir(BaseModel):
 
     fdir: pathlib.Path
     recursive: bool = True
-    patterns: List[str] = Field([], description=patherns_des)
+    patterns: List[str] = Field([], description=PATTERNS_DES)
     fpths: List[pathlib.Path] = []
 
     @validator("fdir", always=True)
@@ -86,7 +80,7 @@ class FilesInDir(BaseModel):
 
 
 # +
-class ListStrings(w.VBox, HasTraits):
+class ListStrings(w.VBox, tr.HasTraits):
     value = tr.List()
 
     def __init__(self, value):
@@ -136,7 +130,7 @@ class MatchStrings(ListStrings):
 # -
 
 
-class FindFiles(w.VBox, HasTraits):
+class FindFiles(w.VBox, tr.HasTraits):
     value = tr.Dict()
 
     def __init__(

--- a/src/ipyautoui/custom/fileupload.py
+++ b/src/ipyautoui/custom/fileupload.py
@@ -13,14 +13,12 @@ import stringcase
 from datetime import datetime
 import traitlets as tr
 import json
-import traitlets_paths
 
-from ipyautoui.automapschema import attach_schema_refs
-from ipyautoui.constants import BUTTON_MIN_SIZE, KWARGS_OPENFOLDER, DELETE_BUTTON_KWARGS
-from ipyautoui._utils import open_file, obj_to_importstr, getuser
-from ipyautoui.autodisplay import AutoDisplay, DisplayObject
-from ipyautoui.custom.iterable import Array, AutoArray, Dictionary
-from ipyautoui.autodisplayfile_renderers import preview_image, render_file
+from ipyautoui.constants import DELETE_BUTTON_KWARGS
+from ipyautoui._utils import getuser
+from ipyautoui.autodisplay import DisplayObject
+from ipyautoui.custom.iterable import Dictionary
+from ipyautoui.autodisplayfile_renderers import render_file
 from IPython.display import clear_output
 
 IS_IPYWIDGETS8 = (lambda: True if "8" in w.__version__ else False)()

--- a/src/ipyautoui/custom/iterable.py
+++ b/src/ipyautoui/custom/iterable.py
@@ -77,10 +77,7 @@ import ipywidgets as w
 import traitlets as tr
 from traitlets import validate
 import typing as ty
-import immutables
 from IPython.display import display
-
-# from pydantic.dataclasses import dataclass
 from ipyautoui.basemodel import BaseModel
 from pydantic import validator
 import uuid
@@ -95,19 +92,15 @@ from ipyautoui.constants import (
     BUTTON_HEIGHT_MIN,
     BUTTON_MIN_SIZE,
 )
+from ipyautoui._utils import frozenmap
+from ipyautoui.autowidgets import create_widget_caller
 
-
-frozenmap = immutables.Map
-# ^ https://www.python.org/dev/peps/pep-0603/, https://github.com/MagicStack/immutables
 BOX = frozenmap({True: w.HBox, False: w.VBox})
 TOGGLE_BUTTON_KWARGS = frozenmap(
     icon="",
     layout={"width": BUTTON_WIDTH_MIN, "height": BUTTON_HEIGHT_MIN},
 )
 # -
-from ipyautoui.autowidgets import create_widget_caller
-from ipyautoui.autoipywidget import AutoObject
-
 
 # +
 class IterableItem(BaseModel):

--- a/src/ipyautoui/custom/markdown_widget.py
+++ b/src/ipyautoui/custom/markdown_widget.py
@@ -22,9 +22,7 @@ import ipywidgets as w
 import functools
 import traitlets as tr
 from IPython.display import Markdown, clear_output, display
-import immutables
-
-frozenmap = immutables.Map
+from ipyautoui._utils import frozenmap
 
 # +
 BUTTON_MIN_SIZE = frozenmap(**{"width": "41px", "height": "25px"})

--- a/src/ipyautoui/custom/modelrun.py
+++ b/src/ipyautoui/custom/modelrun.py
@@ -16,8 +16,8 @@
 
 import re
 import ipywidgets as w
-from traitlets import HasTraits, Unicode, default, validate, TraitError
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
+import traitlets as tr
 import typing as ty
 
 
@@ -73,16 +73,16 @@ class RunName(w.HBox):
         zfill = 2
     """
 
-    _value = Unicode()
+    _value = tr.Unicode()
 
-    @validate("_value")
+    @tr.validate("_value")
     def _valid_value(self, proposal):
         val = proposal["value"]
         matched = re.match(self.inputs.pattern, val)
         if not bool(matched):
             print(self.inputs.pattern)
             print(val)
-            raise TraitError(f"string musts have format: {self.inputs.pattern}")
+            raise tr.TraitError(f"string musts have format: {self.inputs.pattern}")
         return val
 
     @property
@@ -90,7 +90,7 @@ class RunName(w.HBox):
         return self._value
 
     @value.setter
-    def value(self, value: Unicode):
+    def value(self, value: tr.Unicode):
         """The setter allows a user to pass a new value field to the class. This also updates the
         `selected` argument used by RunName"""
         if value is not None:

--- a/src/ipyautoui/custom/multiselect_search.py
+++ b/src/ipyautoui/custom/multiselect_search.py
@@ -23,11 +23,8 @@ Reference:
 
 """
 # %run ../__init__.py
-import sys
 import ipywidgets as w
 import traitlets as tr
-import requests
-import random
 
 BUTTON_WIDTH_MIN = "50px"
 

--- a/src/ipyautoui/custom/save_buttonbar.py
+++ b/src/ipyautoui/custom/save_buttonbar.py
@@ -17,28 +17,17 @@
 # %run __init__.py
 # %load_ext lab_black
 
-import pathlib
-import functools
-import pandas as pd
 import ipywidgets as w
-from IPython.display import display, Markdown, clear_output
-from datetime import datetime, date
-from dataclasses import dataclass
-from pydantic import BaseModel
+from IPython.display import display
+from datetime import datetime
 from markdown import markdown
-import immutables
-import json
 import traitlets as tr
 import typing as ty
-from enum import Enum
 import logging
-
 from ipyautoui.constants import (
-    MAP_JSONSCHEMA_TO_IPYWIDGET,
     BUTTON_WIDTH_MIN,
     TOGGLEBUTTON_ONCLICK_BORDER_LAYOUT,
 )
-
 
 # +
 def merge_callables(callables: ty.Union[ty.Callable, ty.List[ty.Callable]]):

--- a/src/ipyautoui/custom/selectdir.py
+++ b/src/ipyautoui/custom/selectdir.py
@@ -16,35 +16,23 @@
 # +
 # %run __init__.py
 # %load_ext lab_black
-
+from IPython.display import display
 from ipyautoui.basemodel import BaseModel
 from ipyautoui.basemodel import file
+from ipyautoui._utils import file
 
 setattr(BaseModel, "file", file)
 from pydantic import validator, Field, ValidationError
-from ipyautoui.constants import LOAD_BUTTON_KWARGS, BUTTON_MIN_SIZE, BUTTON_WIDTH_MIN
+from ipyautoui.constants import LOAD_BUTTON_KWARGS
 from IPython.display import clear_output, Markdown
-from ipyautoui._utils import file
-import shutil
-import traitlets_paths
+
 import ipywidgets as w
 import traitlets as tr
 import typing as ty
-
-import os
-from halo import HaloNotebook
-from enum import Enum, IntEnum
 import pathlib
-from pydantic import BaseModel, ValidationError
-import typing as ty
 from datetime import datetime
-import zipfile
-import logging
-import seedir
-from ipyautoui._utils import obj_to_importstr, getuser
+from ipyautoui._utils import obj_to_importstr, getuser, make_new_path
 from ipyautoui.custom.decision_branch import DecisionUi, TreeModel
-
-from ipyautoui._utils import make_new_path
 
 # -
 

--- a/src/ipyautoui/custom/showhide.py
+++ b/src/ipyautoui/custom/showhide.py
@@ -18,7 +18,6 @@
 # %load_ext lab_black
 
 # +
-import traitlets_paths
 import ipywidgets as w
 import traitlets as t
 from IPython.display import clear_output, display

--- a/src/ipyautoui/custom/workingdir.py
+++ b/src/ipyautoui/custom/workingdir.py
@@ -23,25 +23,21 @@ a UI element that loads a folder for data caching, whilst storing a record of fo
 
 # +
 from pydantic import BaseModel, validator, Field
-from ipyautoui.constants import LOAD_BUTTON_KWARGS, BUTTON_MIN_SIZE, BUTTON_WIDTH_MIN
+from ipyautoui.constants import LOAD_BUTTON_KWARGS, BUTTON_WIDTH_MIN
 from IPython.display import clear_output, Markdown
 from ipyautoui._utils import file
-import shutil
-import traitlets_paths
 import ipywidgets as w
 import traitlets as tr
 
 from getpass import getuser
 import os
 from halo import HaloNotebook
-from enum import Enum, IntEnum
+from enum import Enum
 import pathlib
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 import typing as ty
 from datetime import datetime
-import zipfile
 import logging
-import seedir
 from ipyautoui._utils import obj_to_importstr
 
 try:

--- a/src/ipyautoui/demo.py
+++ b/src/ipyautoui/demo.py
@@ -1,16 +1,17 @@
 import traitlets as tr
-import typing as ty
 from traitlets_paths import PurePath
+import typing as ty
 import ipywidgets as w
 import inspect
-from ipyautoui.demo_schemas import CoreIpywidgets
-from ipyautoui._utils import display_python_file
-from ipyautoui import AutoUi
+from pydantic import BaseModel
 from IPython.display import display, clear_output, Markdown
 import json
 import pathlib
-from pydantic import BaseModel
+
 from ipyautoui import demo_schemas as demo_schemas
+from ipyautoui.demo_schemas import CoreIpywidgets
+from ipyautoui._utils import display_python_file
+from ipyautoui import AutoUi
 
 # TODO: add AutoRenderer functionality to demo
 
@@ -59,7 +60,13 @@ class Demo(w.Tab, tr.HasTraits):
         self.vbx_jsonschema = w.VBox()
         self.vbx_jsonschema_caller = w.VBox()
         self.vbx_value = w.VBox()
-        titles = {0: "AutoUi", 1: "pydantic-model", 2: "jsonschema", 3: "jsonschema-caller", 4: "autoui-value"}
+        titles = {
+            0: "AutoUi",
+            1: "pydantic-model",
+            2: "jsonschema",
+            3: "jsonschema-caller",
+            4: "autoui-value",
+        }
         self.children = [
             self.vbx_autoui,
             self.vbx_pydantic,

--- a/src/ipyautoui/test_schema.py
+++ b/src/ipyautoui/test_schema.py
@@ -1,5 +1,7 @@
 """
 An example schema definition that demonstrates the current capability of the AutoUi class
+
+# TODO: delete this file.
 """
 import typing as ty
 from enum import Enum
@@ -8,7 +10,6 @@ from ipyautoui.basemodel import BaseModel
 from pydantic.color import Color
 from datetime import datetime, date
 import pathlib
-import pandas as pd
 from pathlib import PurePosixPath
 
 # from ipyautoui.custom.modelrun import RunName
@@ -56,7 +57,7 @@ class DataFrameCols(BaseModel):
     floater: float = Field(3.1415, aui_column_width=70, aui_sig_fig=3)
     something_else: float = Field(324, aui_column_width=100)
 
-    
+
 class TestEditGrid(BaseModel):
     editgrid: ty.List[DataFrameCols] = Field(
         default=DATAGRID_TEST_VALUE,
@@ -107,6 +108,7 @@ class TestAutoLogicSimple(BaseModel):
     )
     # file_chooser: pathlib.Path = pathlib.Path(".") # TODO: serialisation / parsing round trip not working...
 
+
 class TestTypesWithComplexSerialisation(BaseModel):
     """all of these types need to be serialised to json and parsed back to objects upon reading..."""
 
@@ -120,10 +122,12 @@ class TestTypesWithComplexSerialisation(BaseModel):
         datetime
     ] = datetime.now()  # TODO: update with ipywidgets-v8
     color_picker_ipywidgets: Color = "#f5f595"
-    
+
+
 class TestNested(BaseModel):
     nested: NestedObject = Field(default=None)
-    # recursive_nest: RecursiveNest = Field(default=None) # NOTE: this isn't working! 
+    # recursive_nest: RecursiveNest = Field(default=None) # NOTE: this isn't working!
+
 
 class TestAutoLogic(TestAutoLogicSimple, TestEditGrid, TestNested):
     """this is a test UI form to demonstrate how pydantic class can be used to generate an ipywidget input form"""

--- a/tests/filetypes/eg_py.py
+++ b/tests/filetypes/eg_py.py
@@ -3,7 +3,6 @@ a dummy python file that needs to be allowed to be executed for doctest to run..
 """
 
 import os 
-import xmltodict
 from IPython.display import HTML, Markdown, JSON, display, Image, FileLink, FileLinks
 import pandas as pd
 import numpy as np

--- a/tests/test_autoipywidget.py
+++ b/tests/test_autoipywidget.py
@@ -11,6 +11,7 @@ import pathlib
 # from ipyautoui.tests import test_display_widget_mapping
 from .constants import DIR_TESTS, DIR_FILETYPES
 from .example_objects import ExampleRoot, ExampleSchema
+
 from ipyautoui import AutoUi, AutoDisplay, AutoVjsf
 from ipyautoui.autoipywidget import AutoObject, demo_autoobject_form
 from ipyautoui.demo_schemas import RootEnum, RootArrayEnum


### PR DESCRIPTION
removed some unneeded deps (e.g. `seedir`) and generally reviewed / tidied module imports