### PR TITLE
✨-support-rebasing-relative-data-to-notebook-dir

### DIFF
--- a/docs/__init__.py
+++ b/docs/__init__.py
@@ -1,0 +1,4 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(".").absolute().parent / "src"))

--- a/docs/autodisplay.ipynb
+++ b/docs/autodisplay.ipynb
@@ -19,13 +19,24 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "cd1a6c89-b5c1-4234-99e8-ad4a93036de8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run __init__.py\n",
+    "%load_ext lab_black"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "d1307a87-a12c-4f53-8c31-e383eca373e3",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ceab4615db304f0ab4d82e788421d2bb",
+       "model_id": "33a1fd25fd604a2c8d6651be40e41caa",
        "version_major": 2,
        "version_minor": 0
       },
@@ -38,7 +49,6 @@
     }
    ],
    "source": [
-    "import pathlib\n",
     "from ipyautoui.test_schema import TestAutoLogic\n",
     "from ipyautoui import AutoUi, AutoDisplay\n",
     "from ipyautoui.constants import load_test_constants\n",
@@ -63,14 +73,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "7b833bf5-5c24-4e38-8d2e-393558dde75e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "372cf3a2f29b48c382832bf0774e95d9",
+       "model_id": "2faff57d767c458dbe6de33291ef8190",
        "version_major": 2,
        "version_minor": 0
       },
@@ -83,7 +93,6 @@
     }
    ],
    "source": [
-    "\n",
     "from ipyautoui.test_schema import TestAutoLogic\n",
     "\n",
     "user_file_renderers = AutoUi.create_autodisplay_map(\n",
@@ -96,8 +105,16 @@
     "    display_showhide=False,\n",
     ")\n",
     "\n",
-    "display(test_ui)\n"
+    "display(test_ui)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d7e3a4e-b7f9-4ff6-a9de-bb10e49851a0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -116,7 +133,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   },
   "vscode": {
    "interpreter": {

--- a/docs/demo.ipynb
+++ b/docs/demo.ipynb
@@ -17,7 +17,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3611856c92cd4e719641f8681a316f7a",
+       "model_id": "025c0e509a824e87827f548a06915477",
        "version_major": 2,
        "version_minor": 0
       },

--- a/src/ipyautoui/custom/markdown_widget.py
+++ b/src/ipyautoui/custom/markdown_widget.py
@@ -24,6 +24,8 @@ import traitlets as tr
 from IPython.display import Markdown, clear_output, display
 from ipyautoui._utils import frozenmap
 
+# TODO: update the renderer to use pandoc and/or myst, thus getting extended syntax
+
 # +
 BUTTON_MIN_SIZE = frozenmap(**{"width": "41px", "height": "25px"})
 EXAMPLE_MARKDOWN = """
@@ -45,6 +47,7 @@ See details here: [__commonmark__](https://commonmark.org/help/)
 1. item 1
 1. item 1
 1. item 1
+  - sub item
 
 """
 

--- a/src/ipyautoui/env.py
+++ b/src/ipyautoui/env.py
@@ -1,0 +1,24 @@
+from pydantic import BaseSettings, validator, Field
+import pathlib
+import typing as ty
+
+# https://stackoverflow.com/questions/52119454/how-to-obtain-jupyter-notebooks-path
+# ^ impossible to know with clarity the exact filename and directory of a notebook.
+#   it can therefore be explicitly defined as an env var. required for getting rel paths
+
+
+class Env(BaseSettings):
+    IPYAUTOUI_ROOTDIR: ty.Optional[pathlib.Path] = Field(
+        None,
+        description="typically the directory that the Notebook is in."
+        " Required for AutoDisplay to find relative paths to: pdfs, vega, ...",
+    )
+
+    @validator("IPYAUTOUI_ROOTDIR")
+    def _IPYAUTOUI_ROOTDIR(cls, v):
+        """Checks for app.db in parent directory and copies from repo if it does not
+        exist.
+        """
+        if v is None:
+            v = pathlib.Path(".").absolute()
+        return v

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,8 +1,8 @@
 import pathlib
 
 DIR_TESTS = pathlib.Path(__file__).parent
+DIR_REPO = DIR_TESTS.parent
 PATH_TEST_AUI = DIR_TESTS / "testdata" / "test.aui.json"
 DIR_FILETYPES = DIR_TESTS / "filetypes"
-DIR_DOCS = DIR_TESTS.parent / "docs"
-DIR_PACKAGE = DIR_TESTS.parent / "src" / "ipyautoui"
-
+DIR_DOCS = DIR_REPO / "docs"
+DIR_PACKAGE = DIR_REPO / "src" / "ipyautoui"

--- a/tests/filetypes/eg_md.md
+++ b/tests/filetypes/eg_md.md
@@ -1,35 +1,8 @@
-# 09AH-MXF-AHL-ZZ-SH-M-Ss_60_40_17_00-5101
+# Markdown Example
 
-# Cooling Pumps Schedule
+**Markdown** is a plain text format for writing _structured documents_, based on formatting conventions from email and usenet.
 
-![](img/template_files/half_circle-resize_sm.png)
-
-| Rev ![](img/template_files/line_v_short.png)   | Date ![](img/template_files/line_short.png)       | Status ![](img/template_files/line_v_short.png)   | Description ![](img/template_files/line_long.png)   | Engineer ![](img/template_files/line_v_short.png)   | Project Leader   |
-|:------|:-----------|:---------|:--------------|:-----------|:-----------------|
-| P01   | 2020-04-09 | D1       | Costing       | AH         | MP               |
-
-\newpage
-
-### Document Naming Nomenclature
-
-|    | Project   | Originator   | Volume and Systems   | Levels and Locations   | Types of Information   | Roles   | Uniclass 2015 Unique file number   |   Description |
-|---:|:----------|:-------------|:---------------------|:-----------------------|:-----------------------|:--------|:-----------------------------------|--------------:|
-|  0 | 09AH      | MXF          | AHL                  | ZZ                     | SH                     | M       | Ss_60_40_17_00                     |          5101 |
-
-### Issue History
-
-| Rev ![](img/template_files/line_v_short.png)   | Date ![](img/template_files/line_short.png)       | Status ![](img/template_files/line_v_short.png)   | Description ![](img/template_files/line_long.png)   | Engineer ![](img/template_files/line_v_short.png)   | Project Leader   |
-|:------|:-----------|:---------|:--------------|:-----------|:-----------------|
-| P01   | 2020-04-09 | D1       | Costing       | AH         | MP               |
-
-### Notes
-
-|    | Notes: ![](img/template_files/line_v_long.png)                                                                                                                                                                                               |
-|---:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  0 | To be read in conjunction with all other contract documentation,                                                                                                                                     |
-|  1 | References to manufacturers and/or devices thereof are to indicate a general level of functionality and quality. Alternative manufacturers will be considered where equivalence can be demonstrated. |
-|  2 | Contractor to ensure that the catalogue number is consistent with the description prior to order.                                                                                                    |
-|  3 | Contractor to ensure that quantities of equipment are consistent with Architects layout.                                                                                                             |
+See details here: [**commonmark**](https://commonmark.org/help/)
 
 \newpage
 
@@ -37,171 +10,50 @@
 
 \newpage
 
-### P_C_1: AHLN CHW pumps. 2 no. equivalent pumps as run, standby arrangement.
+## Images
 
-#### Images
+**Note**. the images below are relative to the markdown file. When rendering the markdown file pandoc uses [extension-rebase_relative_paths](https://pandoc.org/MANUAL.html#extension-rebase_relative_paths)
+to update the image paths so they are relative to the jupyter notebook. This is required to correctly render the images.
 
-| Model Image ![](img/template_files/line_long.png)             | Product Image ![](img/template_files/line_long.png)           |
-|:------------------------|:------------------------|
-| ![P_C_1](img/P_C_1.png) | ![P_C_1](img/P_C_1.png) |
+![image](eg_dir/eg_jpg_1.jpg)
+![image](eg_dir/eg_png_1.png)
 
-#### Data
+## lists
 
-| Group ![](img/template_files/line_short.png)       | ParameterName ![](img/template_files/line_long.png)                                     | P_C_1 ![](img/template_files/line_long.png)                                                                       |
-|:------------|:--------------------------------------------------|:----------------------------------------------------------------------------|
-| Description | Description                                       | AHLN CHW pumps. 2 no. equivalent pumps as run, standby arrangement.         |
-| Electrical  | Duties - Motor - Nominal voltage                  | Single - phase 230 V a.c.                                                   |
-| Geometry    | Nominal width                                     | 320 mm                                                                      |
-| Geometry    | Nominal height                                    | 430 mm                                                                      |
-| Geometry    | Nominal length                                    | 280 mm                                                                      |
-| Identity    | Manufacturer                                      | Grundfos/Armstrong/Wilo                                                     |
-| Identity    | Duties - Reference                                | PN10                                                                        |
-| Technical   | Material                                          | Pump impeller; stainless steel.                                             |
-|             |                                                   | Body gasket: EDPM.                                                          |
-|             |                                                   | Air vent screw: brass.                                                      |
-| Technical   | Anti-vibration mountings                          | To be provided with concrete filled inertia base and anti-vibration mounts. |
-| Technical   | Flexible connections                              | Steel wire re-inforced EDPM flexible connectors.                            |
-| Technical   | Accessories                                       | R100 remote control interface equal or equivalent.                          |
-|             |                                                   | Native BACNET (c/w CIU300 interface)                                        |
-| Technical   | Casing material                                   | Pump base; cast iron.                                                       |
-|             |                                                   | Pump head: cast iron.                                                       |
-|             |                                                   | Pump shaft: stainless steel                                                 |
-| Technical   | Speed control                                     | Variable speed, integral inverter                                           |
-| Technical   | Connections - Flanged, copper alloy and composite | 32 mm flanged                                                               |
-| Technical   | General                                           | AHLN Cooling Plantroom serving AHLN                                         |
-| Technical   | Duties - Resistance                               | 130 kPA                                                                     |
-| Technical   | Duties - Application                              | CHW                                                                         |
-| Technical   | Duties - Flow rate                                | 2 l/s per pump                                                              |
-| Technical   | Duties - Operation                                | Run/Standby configuration.                                                  |
-| Technical   | Arrangement                                       | Single head circulator.                                                     |
-| Technical   | Duties - Rated Power                              | 0.75 kW, 4.7 A                                                              |
-| Technical   | Duties - Motor - Frequency                        | 50 Hz.                                                                      |
+- **bold**
+- _italic_
+- `inline code`
+- [links](https://www.markdownguide.org/basic-syntax/)
+  - sub-item
 
-\newpage
+## numbers
 
-### P_C_2: AHLN CHW pumps. 2 no. equivalent pumps as run, standby arrangement.
+1. item 1
+1. item 1
+1. item 1
+   1. sub item
+  
+## Tables
 
-#### Images
+## Pipe tables
 
-| Model Image ![](img/template_files/line_long.png)             | Product Image ![](img/template_files/line_long.png)           |
-|:------------------------|:------------------------|
-| ![P_C_2](img/P_C_2.png) | ![P_C_2](img/P_C_2.png) |
+|   | Notes                                                                                                                                                                                                |
+|--:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0 | To be read in conjunction with all other contract documentation,                                                                                                                                     |
+| 1 | References to manufacturers and/or devices thereof are to indicate a general level of functionality and quality. Alternative manufacturers will be considered where equivalence can be demonstrated. |
+| 2 | Contractor to ensure that the catalogue number is consistent with the description prior to order.                                                                                                    |
+| 3 | Contractor to ensure that quantities of equipment are consistent with Architects layout.                                                                                                             |
 
-#### Data
+## Grid tables
 
-| Group ![](img/template_files/line_short.png)       | ParameterName ![](img/template_files/line_long.png)                                     | P_C_2 ![](img/template_files/line_long.png)                                                                       |
-|:------------|:--------------------------------------------------|:----------------------------------------------------------------------------|
-| Description | Description                                       | AHLN CHW pumps. 2 no. equivalent pumps as run, standby arrangement.         |
-| Electrical  | Duties - Motor - Nominal voltage                  | Single - phase 230 V a.c.                                                   |
-| Geometry    | Nominal width                                     | 320 mm                                                                      |
-| Geometry    | Nominal height                                    | 430 mm                                                                      |
-| Geometry    | Nominal length                                    | 280 mm                                                                      |
-| Identity    | Manufacturer                                      | Grundfos/Armstrong/Wilo                                                     |
-| Identity    | Duties - Reference                                | PN10                                                                        |
-| Technical   | Material                                          | Pump impeller; stainless steel.                                             |
-|             |                                                   | Body gasket: EDPM.                                                          |
-|             |                                                   | Air vent screw: brass.                                                      |
-| Technical   | Anti-vibration mountings                          | To be provided with concrete filled inertia base and anti-vibration mounts. |
-| Technical   | Flexible connections                              | Steel wire re-inforced EDPM flexible connectors.                            |
-| Technical   | Accessories                                       | R100 remote control interface equal or equivalent.                          |
-|             |                                                   | Native BACNET (c/w CIU300 interface)                                        |
-| Technical   | Casing material                                   | Pump base; cast iron.                                                       |
-|             |                                                   | Pump head: cast iron.                                                       |
-|             |                                                   | Pump shaft: stainless steel                                                 |
-| Technical   | Speed control                                     | Variable speed, integral inverter                                           |
-| Technical   | Connections - Flanged, copper alloy and composite | 32 mm flanged                                                               |
-| Technical   | General                                           | AHLN Cooling Plantroom serving AHLN                                         |
-| Technical   | Duties - Resistance                               | 130 kPA                                                                     |
-| Technical   | Duties - Application                              | CHW                                                                         |
-| Technical   | Duties - Flow rate                                | 2 l/s per pump                                                              |
-| Technical   | Duties - Operation                                | Run/Standby configuration.                                                  |
-| Technical   | Arrangement                                       | Single head circulator.                                                     |
-| Technical   | Duties - Rated Power                              | 0.75 kW, 4.7 A                                                              |
-| Technical   | Duties - Motor - Frequency                        | 50 Hz.                                                                      |
+Grid tables make it easier to specify complex formatting within cells...
 
-\newpage
-
-### P_C_3: AHLS CHW pumps. 2 no. equivalent pumps as run, standby arrangement.
-
-#### Images
-
-| Model Image ![](img/template_files/line_long.png)             | Product Image ![](img/template_files/line_long.png)           |
-|:------------------------|:------------------------|
-| ![P_C_3](img/P_C_3.png) | ![P_C_3](img/P_C_3.png) |
-
-#### Data
-
-| Group ![](img/template_files/line_short.png)       | ParameterName ![](img/template_files/line_long.png)                                     | P_C_3 ![](img/template_files/line_long.png)                                                                       |
-|:------------|:--------------------------------------------------|:----------------------------------------------------------------------------|
-| Description | Description                                       | AHLS CHW pumps. 2 no. equivalent pumps as run, standby arrangement.         |
-| Electrical  | Duties - Motor - Nominal voltage                  | Single - phase 230 V a.c.                                                   |
-| Geometry    | Nominal width                                     | 320 mm                                                                      |
-| Geometry    | Nominal height                                    | 440 mm                                                                      |
-| Geometry    | Nominal length                                    | 220 mm                                                                      |
-| Identity    | Manufacturer                                      | Grundfos/Armstrong/Wilo                                                     |
-| Identity    | Duties - Reference                                | PN10                                                                        |
-| Technical   | Material                                          | Pump impeller; stainless steel.                                             |
-|             |                                                   | Body gasket: EDPM.                                                          |
-|             |                                                   | Air vent screw: brass.                                                      |
-| Technical   | Anti-vibration mountings                          | To be provided with concrete filled inertia base and anti-vibration mounts. |
-| Technical   | Flexible connections                              | Steel wire re-inforced EDPM flexible connectors.                            |
-| Technical   | Accessories                                       | R100 remote control interface equal or equivalent.                          |
-|             |                                                   | Native BACNET (c/w CIU300 interface)                                        |
-| Technical   | Casing material                                   | Pump base; cast iron.                                                       |
-|             |                                                   | Pump head: cast iron.                                                       |
-|             |                                                   | Pump shaft: stainless steel                                                 |
-| Technical   | Speed control                                     | Variable speed, integral inverter                                           |
-| Technical   | Connections - Flanged, copper alloy and composite | 32 mm flanged                                                               |
-| Technical   | General                                           | AHLS Cooling Plantroom serving AHLS                                         |
-| Technical   | Duties - Resistance                               | 115 kPa                                                                     |
-| Technical   | Duties - Application                              | CHW                                                                         |
-| Technical   | Duties - Flow rate                                | 0.7 l/s per pump                                                            |
-| Technical   | Duties - Operation                                | Run/Standby configuration.                                                  |
-| Technical   | Arrangement                                       | Single head circulator.                                                     |
-| Technical   | Duties - Rated Power                              | 0.37 kW, 2.6 A                                                              |
-| Technical   | Duties - Motor - Frequency                        | 50 Hz.                                                                      |
-
-\newpage
-
-### P_C_4: AHLS CHW pumps. 2 no. equivalent pumps as run, standby arrangement.
-
-#### Images
-
-| Model Image ![](img/template_files/line_long.png)             | Product Image ![](img/template_files/line_long.png)           |
-|:------------------------|:------------------------|
-| ![P_C_4](img/P_C_4.png) | ![P_C_4](img/P_C_4.png) |
-
-#### Data
-
-| Group ![](img/template_files/line_short.png)       | ParameterName ![](img/template_files/line_long.png)                                     | P_C_4 ![](img/template_files/line_long.png)                                                                       |
-|:------------|:--------------------------------------------------|:----------------------------------------------------------------------------|
-| Description | Description                                       | AHLS CHW pumps. 2 no. equivalent pumps as run, standby arrangement.         |
-| Electrical  | Duties - Motor - Nominal voltage                  | Single - phase 230 V a.c.                                                   |
-| Geometry    | Nominal width                                     | 320 mm                                                                      |
-| Geometry    | Nominal height                                    | 440 mm                                                                      |
-| Geometry    | Nominal length                                    | 220 mm                                                                      |
-| Identity    | Manufacturer                                      | Grundfos/Armstrong/Wilo                                                     |
-| Identity    | Duties - Reference                                | PN10                                                                        |
-| Technical   | Material                                          | Pump impeller; stainless steel.                                             |
-|             |                                                   | Body gasket: EDPM.                                                          |
-|             |                                                   | Air vent screw: brass.                                                      |
-| Technical   | Anti-vibration mountings                          | To be provided with concrete filled inertia base and anti-vibration mounts. |
-| Technical   | Flexible connections                              | Steel wire re-inforced EDPM flexible connectors.                            |
-| Technical   | Accessories                                       | R100 remote control interface equal or equivalent.                          |
-|             |                                                   | Native BACNET (c/w CIU300 interface)                                        |
-| Technical   | Casing material                                   | Pump base; cast iron.                                                       |
-|             |                                                   | Pump head: cast iron.                                                       |
-|             |                                                   | Pump shaft: stainless steel                                                 |
-| Technical   | Speed control                                     | Variable speed, integral inverter                                           |
-| Technical   | Connections - Flanged, copper alloy and composite | 32 mm flanged                                                               |
-| Technical   | General                                           | AHLS Cooling Plantroom serving AHLS                                         |
-| Technical   | Duties - Resistance                               | 115 kPa                                                                     |
-| Technical   | Duties - Application                              | CHW                                                                         |
-| Technical   | Duties - Flow rate                                | 0.7 l/s per pump                                                            |
-| Technical   | Duties - Operation                                | Run/Standby configuration.                                                  |
-| Technical   | Arrangement                                       | Single head circulator.                                                     |
-| Technical   | Duties - Rated Power                              | 0.37 kW, 2.6 A                                                              |
-| Technical   | Duties - Motor - Frequency                        | 50 Hz.                                                                      |
-
-\newpage
-
++---------------+---------------+--------------------+
+| Fruit         | Price         | Advantages         |
++===============+===============+====================+
+| Bananas       | $1.34         | - built-in wrapper |
+|               |               | - bright color     |
++---------------+---------------+--------------------+
+| Oranges       | $2.10         | - cures scurvy     |
+|               |               | - tasty            |
++---------------+---------------+--------------------+

--- a/tests/filetypes/eg_vega_waterfall.vg.json
+++ b/tests/filetypes/eg_vega_waterfall.vg.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {
+    "values": [
+      {"label": "Begin", "amount": 4000},
+      {"label": "Jan", "amount": 1707},
+      {"label": "Feb", "amount": -1425},
+      {"label": "Mar", "amount": -1030},
+      {"label": "Apr", "amount": 1812},
+      {"label": "May", "amount": -1067},
+      {"label": "Jun", "amount": -1481},
+      {"label": "Jul", "amount": 1228},
+      {"label": "Aug", "amount": 1176},
+      {"label": "Sep", "amount": 1146},
+      {"label": "Oct", "amount": 1205},
+      {"label": "Nov", "amount": -1388},
+      {"label": "Dec", "amount": 1492},
+      {"label": "End", "amount": 0}
+    ]
+  },
+  "width": 800,
+  "height": 450,
+  "transform": [
+    {"window": [{"op": "sum", "field": "amount", "as": "sum"}]},
+    {"window": [{"op": "lead", "field": "label", "as": "lead"}]},
+    {
+      "calculate": "datum.lead === null ? datum.label : datum.lead",
+      "as": "lead"
+    },
+    {
+      "calculate": "datum.label === 'End' ? 0 : datum.sum - datum.amount",
+      "as": "previous_sum"
+    },
+    {
+      "calculate": "datum.label === 'End' ? datum.sum : datum.amount",
+      "as": "amount"
+    },
+    {
+      "calculate": "(datum.label !== 'Begin' && datum.label !== 'End' && datum.amount > 0 ? '+' : '') + datum.amount",
+      "as": "text_amount"
+    },
+    {"calculate": "(datum.sum + datum.previous_sum) / 2", "as": "center"},
+    {
+      "calculate": "datum.sum < datum.previous_sum ? datum.sum : ''",
+      "as": "sum_dec"
+    },
+    {
+      "calculate": "datum.sum > datum.previous_sum ? datum.sum : ''",
+      "as": "sum_inc"
+    }
+  ],
+  "encoding": {
+    "x": {
+      "field": "label",
+      "type": "ordinal",
+      "sort": null,
+      "axis": {"labelAngle": 0, "title": "Months"}
+    }
+  },
+  "layer": [
+    {
+      "mark": {"type": "bar", "size": 45},
+      "encoding": {
+        "y": {
+          "field": "previous_sum",
+          "type": "quantitative",
+          "title": "Amount"
+        },
+        "y2": {"field": "sum"},
+        "color": {
+          "condition": [
+            {
+              "test": "datum.label === 'Begin' || datum.label === 'End'",
+              "value": "#f7e0b6"
+            },
+            {"test": "datum.sum < datum.previous_sum", "value": "#f78a64"}
+          ],
+          "value": "#93c4aa"
+        }
+      }
+    },
+    {
+      "mark": {
+        "type": "rule",
+        "color": "#404040",
+        "opacity": 1,
+        "strokeWidth": 2,
+        "xOffset": -22.5,
+        "x2Offset": 22.5
+      },
+      "encoding": {
+        "x2": {"field": "lead"},
+        "y": {"field": "sum", "type": "quantitative"}
+      }
+    },
+    {
+      "mark": {"type": "text", "dy": -4, "baseline": "bottom"},
+      "encoding": {
+        "y": {"field": "sum_inc", "type": "quantitative"},
+        "text": {"field": "sum_inc", "type": "nominal"}
+      }
+    },
+    {
+      "mark": {"type": "text", "dy": 4, "baseline": "top"},
+      "encoding": {
+        "y": {"field": "sum_dec", "type": "quantitative"},
+        "text": {"field": "sum_dec", "type": "nominal"}
+      }
+    },
+    {
+      "mark": {"type": "text", "fontWeight": "bold", "baseline": "middle"},
+      "encoding": {
+        "y": {"field": "center", "type": "quantitative"},
+        "text": {"field": "text_amount", "type": "nominal"},
+        "color": {
+          "condition": [
+            {
+              "test": "datum.label === 'Begin' || datum.label === 'End'",
+              "value": "#725a30"
+            }
+          ],
+          "value": "white"
+        }
+      }
+    }
+  ],
+  "config": {"text": {"fontWeight": "bold", "color": "#404040"}}
+}

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,14 @@
+import os
+from ipyautoui.env import Env
+from .constants import DIR_REPO, DIR_TESTS
+
+
+class TestEnv:
+    def test_dev_env(self):
+        env = Env()
+        assert env.IPYAUTOUI_ROOTDIR == DIR_REPO
+
+    def test_set_env(self):
+        os.environ["IPYAUTOUI_ROOTDIR"] = str(DIR_TESTS)
+        env = Env()
+        assert env.IPYAUTOUI_ROOTDIR == DIR_TESTS


### PR DESCRIPTION
pdf, markdown and vega all require paths to be relative to the rendering notebook rather than the file that is rendered. This PR adds support for this. It does this by getting the notebook dir (`pathlib.Path(".").absolute()`), or if explicitly given (robust -method) by using the `IPYAUTOUI_ROOTDIR` env var. 