### PR TITLE
✨add-transposed-view-to-EditGrid

### DIFF
--- a/docs/autoui.ipynb
+++ b/docs/autoui.ipynb
@@ -40,14 +40,52 @@
    "metadata": {},
    "outputs": [
     {
+     "ename": "AttributeError",
+     "evalue": "'NoneType' object has no attribute 'items'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [2]\u001b[0m, in \u001b[0;36m<cell line: 3>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mipyautoui\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m demo\n\u001b[0;32m----> 3\u001b[0m \u001b[43mdemo\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/mnt/c/engDev/git_mf/ipyautoui/src/ipyautoui/demo.py:193\u001b[0m, in \u001b[0;36mdemo\u001b[0;34m()\u001b[0m\n\u001b[1;32m    192\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mdemo\u001b[39m():\n\u001b[0;32m--> 193\u001b[0m     display(\u001b[43mDemoReel\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m)\n",
+      "File \u001b[0;32m/mnt/c/engDev/git_mf/ipyautoui/src/ipyautoui/demo.py:179\u001b[0m, in \u001b[0;36mDemoReel.__init__\u001b[0;34m(self, pydantic_models)\u001b[0m\n\u001b[1;32m    176\u001b[0m \u001b[38;5;66;03m# self.vbx_select.layout\u001b[39;00m\n\u001b[1;32m    178\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpydantic_models \u001b[38;5;241m=\u001b[39m pydantic_models\n\u001b[0;32m--> 179\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdemo \u001b[38;5;241m=\u001b[39m \u001b[43mDemo\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    180\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mchildren \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvbx_select, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdemo]\n\u001b[1;32m    181\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_init_controls()\n",
+      "File \u001b[0;32m/mnt/c/engDev/git_mf/ipyautoui/src/ipyautoui/demo.py:89\u001b[0m, in \u001b[0;36mDemo.__init__\u001b[0;34m(self, pydantic_model)\u001b[0m\n\u001b[1;32m     87\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mout_value \u001b[38;5;241m=\u001b[39m w\u001b[38;5;241m.\u001b[39mOutput()\n\u001b[1;32m     88\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvbx_value\u001b[38;5;241m.\u001b[39mchildren \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mout_value]\n\u001b[0;32m---> 89\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpydantic_model \u001b[38;5;241m=\u001b[39m pydantic_model\n",
+      "File \u001b[0;32m~/mambaforge/envs/ipyautoui-dev/lib/python3.9/site-packages/traitlets/traitlets.py:606\u001b[0m, in \u001b[0;36mTraitType.__set__\u001b[0;34m(self, obj, value)\u001b[0m\n\u001b[1;32m    604\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m TraitError(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mThe \u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m trait is read-only.\u001b[39m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mname)\n\u001b[1;32m    605\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 606\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mset\u001b[49m\u001b[43m(\u001b[49m\u001b[43mobj\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/ipyautoui-dev/lib/python3.9/site-packages/traitlets/traitlets.py:595\u001b[0m, in \u001b[0;36mTraitType.set\u001b[0;34m(self, obj, value)\u001b[0m\n\u001b[1;32m    591\u001b[0m     silent \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m\n\u001b[1;32m    592\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m silent \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mTrue\u001b[39;00m:\n\u001b[1;32m    593\u001b[0m     \u001b[38;5;66;03m# we explicitly compare silent to True just in case the equality\u001b[39;00m\n\u001b[1;32m    594\u001b[0m     \u001b[38;5;66;03m# comparison above returns something other than True/False\u001b[39;00m\n\u001b[0;32m--> 595\u001b[0m     \u001b[43mobj\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_notify_trait\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mold_value\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnew_value\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/ipyautoui-dev/lib/python3.9/site-packages/traitlets/traitlets.py:1219\u001b[0m, in \u001b[0;36mHasTraits._notify_trait\u001b[0;34m(self, name, old_value, new_value)\u001b[0m\n\u001b[1;32m   1218\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_notify_trait\u001b[39m(\u001b[38;5;28mself\u001b[39m, name, old_value, new_value):\n\u001b[0;32m-> 1219\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mnotify_change\u001b[49m\u001b[43m(\u001b[49m\u001b[43mBunch\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   1220\u001b[0m \u001b[43m        \u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1221\u001b[0m \u001b[43m        \u001b[49m\u001b[43mold\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mold_value\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1222\u001b[0m \u001b[43m        \u001b[49m\u001b[43mnew\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mnew_value\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1223\u001b[0m \u001b[43m        \u001b[49m\u001b[43mowner\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1224\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43mtype\u001b[39;49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mchange\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1225\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/ipyautoui-dev/lib/python3.9/site-packages/ipywidgets/widgets/widget.py:606\u001b[0m, in \u001b[0;36mWidget.notify_change\u001b[0;34m(self, change)\u001b[0m\n\u001b[1;32m    603\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m name \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mkeys \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_should_send_property(name, \u001b[38;5;28mgetattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, name)):\n\u001b[1;32m    604\u001b[0m         \u001b[38;5;66;03m# Send new state to front-end\u001b[39;00m\n\u001b[1;32m    605\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msend_state(key\u001b[38;5;241m=\u001b[39mname)\n\u001b[0;32m--> 606\u001b[0m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mWidget\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mnotify_change\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchange\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/ipyautoui-dev/lib/python3.9/site-packages/traitlets/traitlets.py:1229\u001b[0m, in \u001b[0;36mHasTraits.notify_change\u001b[0;34m(self, change)\u001b[0m\n\u001b[1;32m   1227\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mnotify_change\u001b[39m(\u001b[38;5;28mself\u001b[39m, change):\n\u001b[1;32m   1228\u001b[0m     \u001b[38;5;124;03m\"\"\"Notify observers of a change event\"\"\"\u001b[39;00m\n\u001b[0;32m-> 1229\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_notify_observers\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchange\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/ipyautoui-dev/lib/python3.9/site-packages/traitlets/traitlets.py:1266\u001b[0m, in \u001b[0;36mHasTraits._notify_observers\u001b[0;34m(self, event)\u001b[0m\n\u001b[1;32m   1263\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(c, EventHandler) \u001b[38;5;129;01mand\u001b[39;00m c\u001b[38;5;241m.\u001b[39mname \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m   1264\u001b[0m     c \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mgetattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, c\u001b[38;5;241m.\u001b[39mname)\n\u001b[0;32m-> 1266\u001b[0m \u001b[43mc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mevent\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/mnt/c/engDev/git_mf/ipyautoui/src/ipyautoui/demo.py:45\u001b[0m, in \u001b[0;36mDemo._observe_pydantic_model\u001b[0;34m(self, change)\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m:\n\u001b[1;32m     41\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[1;32m     42\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfor the Demo to work, the `pydantic_model` must\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     43\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m be defined in a separate python file.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     44\u001b[0m     )\n\u001b[0;32m---> 45\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_update_autoui\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     46\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_update_pydantic()\n\u001b[1;32m     47\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_update_jsonschema()\n",
+      "File \u001b[0;32m/mnt/c/engDev/git_mf/ipyautoui/src/ipyautoui/demo.py:92\u001b[0m, in \u001b[0;36mDemo._update_autoui\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     91\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_update_autoui\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[0;32m---> 92\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mautoui \u001b[38;5;241m=\u001b[39m \u001b[43mAutoUi\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpydantic_model\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     93\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvbx_autoui\u001b[38;5;241m.\u001b[39mchildren \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mautoui]\n",
+      "File \u001b[0;32m/mnt/c/engDev/git_mf/ipyautoui/src/ipyautoui/autoui.py:267\u001b[0m, in \u001b[0;36mAutoUi.__init__\u001b[0;34m(self, schema, value, path, show_raw, validate_onchange, update_fdir_to_path_parent, **kwargs)\u001b[0m\n\u001b[1;32m    263\u001b[0m \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(\n\u001b[1;32m    264\u001b[0m     schema, value\u001b[38;5;241m=\u001b[39mvalue, update_map_widgets\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, fdir\u001b[38;5;241m=\u001b[39mfdir, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs\n\u001b[1;32m    265\u001b[0m )\n\u001b[1;32m    266\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpath \u001b[38;5;241m=\u001b[39m path\n\u001b[0;32m--> 267\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalue \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_value(value, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpath)\n\u001b[1;32m    268\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mshow_raw \u001b[38;5;241m=\u001b[39m show_raw\n",
+      "File \u001b[0;32m/mnt/c/engDev/git_mf/ipyautoui/src/ipyautoui/autoipywidget.py:500\u001b[0m, in \u001b[0;36mAutoObject.value\u001b[0;34m(self, value)\u001b[0m\n\u001b[1;32m    498\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_value \u001b[38;5;241m=\u001b[39m value\n\u001b[1;32m    499\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdi_widgets\u001b[39m\u001b[38;5;124m\"\u001b[39m):\n\u001b[0;32m--> 500\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_update_widgets_from_value\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/mnt/c/engDev/git_mf/ipyautoui/src/ipyautoui/autoipywidget.py:660\u001b[0m, in \u001b[0;36mAutoObject._update_widgets_from_value\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    659\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_update_widgets_from_value\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[0;32m--> 660\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m k, v \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvalue\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mitems\u001b[49m():\n\u001b[1;32m    661\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m k \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdi_widgets\u001b[38;5;241m.\u001b[39mkeys():\n\u001b[1;32m    662\u001b[0m             \u001b[38;5;28;01mif\u001b[39;00m v \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'NoneType' object has no attribute 'items'"
+     ]
+    }
+   ],
+   "source": [
+    "from ipyautoui import demo\n",
+    "\n",
+    "demo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8110ca46-ced1-4323-be91-2738be9bc2ff",
+   "metadata": {},
+   "outputs": [
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a79146acbcf84d4eb965c4f94af9bc41",
+       "model_id": "d1672ad794024d45a21c65e395618c71",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "DemoReel(children=(VBox(children=(HTML(value='⬇️ -- <b>Select demo pydantic model / generated AutoUi</b> -- ⬇️…"
+       "Dropdown(options=('a', 'b'), value=None)"
       ]
      },
      "metadata": {},
@@ -55,9 +93,7 @@
     }
    ],
    "source": [
-    "from ipyautoui import demo\n",
-    "\n",
-    "demo()"
+    "w.Dropdown(options=[\"a\", \"b\"], value=None)"
    ]
   },
   {
@@ -89,24 +125,12 @@
    "execution_count": 4,
    "id": "80057991",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'd' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [4]\u001b[0m, in \u001b[0;36m<cell line: 6>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mipyautoui\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mtest_schema\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m (\n\u001b[1;32m      2\u001b[0m     TestAutoLogic,\n\u001b[1;32m      3\u001b[0m     TestAutoLogicSimple,\n\u001b[1;32m      4\u001b[0m )  \u001b[38;5;66;03m# the schema shown in the file above\u001b[39;00m\n\u001b[0;32m----> 6\u001b[0m \u001b[43md\u001b[49m\u001b[38;5;241m.\u001b[39mpydantic_model \u001b[38;5;241m=\u001b[39m TestAutoLogicSimple\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'd' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ipyautoui.test_schema import (\n",
     "    TestAutoLogic,\n",
     "    TestAutoLogicSimple,\n",
-    ")  # the schema shown in the file above\n"
+    ")  # the schema shown in the file above"
    ]
   },
   {
@@ -124,21 +148,14 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "changed: text\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d020d96d5e2b4737b2f204dda199a6d9",
+       "model_id": "b735426b336b450c85fa99398ada1cbf",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "AutoUi(children=(SaveButtonBar(children=(ToggleButton(value=True, button_style='danger', disabled=True, icon='…"
+       "AutoUi(children=(SaveButtonBar(children=(ToggleButton(value=False, button_style='success', disabled=True, icon…"
       ]
      },
      "metadata": {},
@@ -152,30 +169,93 @@
     "\n",
     "\n",
     "data = {\"text\": \"this is a value\"}\n",
-    "ui = AutoUi(schema=AutoUiExample, value=data)\n",
+    "ui = AutoUi(schema=AutoUiExample, path=\"test.ui.json\")\n",
     "display(ui)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 39,
+   "id": "e1f990e7-ef47-48ca-9da3-c940a02ac5c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from ipyautoui.basemodel import file\n",
+    "\n",
+    "file(AutoUiExample(), pathlib.Path(\"test.json\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "4e4f84e4-a065-48bc-b1e9-a9a4633c86fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "\"AutoUiExample\" object has no field \"__slots__\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [30]\u001b[0m, in \u001b[0;36m<cell line: 25>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     21\u001b[0m     path\u001b[38;5;241m.\u001b[39mwrite_text(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mjson(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mjson_kwargs), encoding\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mutf-8\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     24\u001b[0m aui \u001b[38;5;241m=\u001b[39m AutoUiExample()\n\u001b[0;32m---> 25\u001b[0m aui\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__slots__\u001b[39m \u001b[38;5;241m=\u001b[39m (\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mfile\u001b[39m\u001b[38;5;124m'\u001b[39m,)\n\u001b[1;32m     26\u001b[0m \u001b[38;5;28msetattr\u001b[39m(aui, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfile\u001b[39m\u001b[38;5;124m\"\u001b[39m, file)\n\u001b[1;32m     29\u001b[0m \u001b[38;5;66;03m#object.__setattr__(aui, \"file\", file)\u001b[39;00m\n",
+      "File \u001b[0;32m~/mambaforge/envs/ipyautoui-dev/lib/python3.9/site-packages/pydantic/main.py:347\u001b[0m, in \u001b[0;36mpydantic.main.BaseModel.__setattr__\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: \"AutoUiExample\" object has no field \"__slots__\""
+     ]
+    }
+   ],
+   "source": [
+    "\"\"\"extending default pydantic BaseModel. NOT IN USE.\"\"\"\n",
+    "import pathlib\n",
+    "from pydantic import BaseModel\n",
+    "from typing import Type\n",
+    "\n",
+    "\n",
+    "def file(self: Type[BaseModel], path: pathlib.Path, **json_kwargs):\n",
+    "    \"\"\"\n",
+    "    this is a method that is added to the pydantic BaseModel within AutoUi using\n",
+    "    \"setattr\".\n",
+    "\n",
+    "    Example:\n",
+    "        ```setattr(model, 'file', file)```\n",
+    "\n",
+    "    Args:\n",
+    "        self (pydantic.BaseModel): instance\n",
+    "        path (pathlib.Path): to write file to\n",
+    "    \"\"\"\n",
+    "    if \"indent\" not in json_kwargs.keys():\n",
+    "        json_kwargs.update({\"indent\": 4})\n",
+    "    path.write_text(self.json(**json_kwargs), encoding=\"utf-8\")\n",
+    "\n",
+    "\n",
+    "aui = AutoUiExample()\n",
+    "aui.__slots__ = ('file',)\n",
+    "setattr(aui, \"file\", file)\n",
+    "\n",
+    "\n",
+    "#object.__setattr__(aui, \"file\", file)\n",
+    "aui.file(pathlib.Path('test.json'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
    "id": "3e527b7d-d046-4087-93eb-c50437f74e55",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "{'text': 'this is a value'}"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "AttributeError",
+     "evalue": "'AutoUiExample' object has no attribute 'file'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [18]\u001b[0m, in \u001b[0;36m<cell line: 2>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m aui \u001b[38;5;241m=\u001b[39m AutoUiExample()\n\u001b[0;32m----> 2\u001b[0m \u001b[43maui\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfile\u001b[49m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'AutoUiExample' object has no attribute 'file'"
+     ]
     }
    ],
-   "source": [
-    "ui.value"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -218,14 +298,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "id": "b4c3a453",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3b489d9c828944fe9c3ffa2dde94c9e2",
+       "model_id": "7a18c335687142d0bfa53229a4eda917",
        "version_major": 2,
        "version_minor": 0
       },
@@ -242,7 +322,13 @@
     "AutoUiRenderer = AutoUi.create_autoui_renderer(schema=AutoUiExample)\n",
     "\n",
     "ui_simple = AutoUiRenderer(path=save_path)\n",
-    "ui_simple.savebuttonbar.fns_onsave_add_action(lambda: print(\"done\"))\n",
+    "\n",
+    "\n",
+    "def test_action():\n",
+    "    print(\"done\")\n",
+    "\n",
+    "\n",
+    "ui_simple.savebuttonbar.fns_onsave_add_action(test_action)\n",
     "ui_simple.show_savebuttonbar = True\n",
     "display(ui_simple)"
    ]
@@ -291,21 +377,14 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "changed: dataframe\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c5337109237b4ec48c120d36eac26b49",
+       "model_id": "43f8090866b8488184bbde8295cf9c74",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "AutoUi(children=(SaveButtonBar(children=(ToggleButton(value=True, button_style='danger', disabled=True, icon='…"
+       "AutoUi(children=(SaveButtonBar(children=(ToggleButton(value=False, button_style='success', disabled=True, icon…"
       ]
      },
      "metadata": {},

--- a/docs/demo.ipynb
+++ b/docs/demo.ipynb
@@ -17,7 +17,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "025c0e509a824e87827f548a06915477",
+       "model_id": "c7b9d5735396429c82bd7a47bc1a2cdf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%run ../src/ipyautoui/__init__.py\n",
+    "%run __init__.py\n",
     "%load_ext lab_black\n",
     "\n",
     "from ipyautoui import demo\n",
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "7b3e8ba2-8580-4e55-bf07-ade428465803",
    "metadata": {},
    "outputs": [],

--- a/src/ipyautoui/autoipywidget.py
+++ b/src/ipyautoui/autoipywidget.py
@@ -495,9 +495,12 @@ class AutoObject(AutoObjectFormLayout):  # w.VBox
     @value.setter
     def value(self, value):
         """this is for setting the value via the API"""
-        self._value = value
-        if hasattr(self, "di_widgets"):
-            self._update_widgets_from_value()
+        if value is None:
+            pass
+        else:
+            self._value = value
+            if hasattr(self, "di_widgets"):
+                self._update_widgets_from_value()
 
     def __init__(
         self,

--- a/src/ipyautoui/automapschema.py
+++ b/src/ipyautoui/automapschema.py
@@ -63,6 +63,7 @@ def flatten_allof(
     return schema
 
 
+# TODO: create a schema handler class for dealing with this.
 def attach_schema_refs(schema, schema_base=None):
     """
     attachs #definitions to $refs within the main schema

--- a/src/ipyautoui/autoui.py
+++ b/src/ipyautoui/autoui.py
@@ -138,7 +138,7 @@ class AutoUiFileMethods(tr.HasTraits):
             return None
         elif v is None and p is not None and p.is_file() == True:
             # load v from p
-            return self.parse_file()
+            return self.parse_file(path=p)
         elif v is None and p is not None and p.is_file() == False:
             # v reverts to schema defaults
             return None
@@ -156,9 +156,9 @@ class AutoUiFileMethods(tr.HasTraits):
     def parse_file(self, path=None) -> dict:
         p = self._get_path(path=path)
         if p.is_file():
-            return parse_json_file(self.path, model=self.model)
+            return parse_json_file(p, model=self.model)
         else:
-            raise ValueError("path.is_file() == False")
+            raise ValueError("p.is_file() == False")
 
     def load_value(self, value, unsaved_changes=False):
         self.value = value
@@ -264,6 +264,7 @@ class AutoUi(AutoObject, AutoUiFileMethods, AutoRenderMethods):
             schema, value=value, update_map_widgets=None, fdir=fdir, **kwargs
         )
         self.path = path
+        self.value = self._get_value(value, self.path)
         self.show_raw = show_raw
 
 

--- a/src/ipyautoui/autoui.py
+++ b/src/ipyautoui/autoui.py
@@ -114,7 +114,7 @@ class AutoUiFileMethods(tr.HasTraits):
         self.savebuttonbar.fns_onrevert_add_action(self.load_file, to_beginning=True)
         self.show_savebuttonbar = True
 
-    def _get_path(self, path=None):
+    def _get_path(self, path=None) -> pathlib.Path:
         if path is None:
             if self.path is not None:
                 return self.path

--- a/src/ipyautoui/autowidgets.py
+++ b/src/ipyautoui/autowidgets.py
@@ -184,9 +184,9 @@ class Dropdown(w.Dropdown):
     >>> sch = CoreIpywidgets.schema()["properties"]['dropdown']
     >>> Dropdown(sch).value
 
-    >>> sch = CoreIpywidgets.schema()["properties"]['dropdown_edge_case']
-    >>> Dropdown(sch).value
-
+    # >>> sch = CoreIpywidgets.schema()["properties"]['dropdown_edge_case']
+    # >>> Dropdown(sch).value
+    # "apple"
     """
 
     def __init__(self, schema):

--- a/src/ipyautoui/autowidgets.py
+++ b/src/ipyautoui/autowidgets.py
@@ -73,6 +73,9 @@ def create_widget_caller(schema, calling=None):
     return caller
 
 
+# TODO: add doctests here
+
+
 class IntText(w.IntText):  # TODO: add value to these as arg?
     def __init__(self, schema):
         self.schema = schema
@@ -81,7 +84,7 @@ class IntText(w.IntText):  # TODO: add value to these as arg?
 
 
 class IntSlider(w.IntSlider):
-    """Example:
+    """extends `ipywidgets.IntSlider`. Example:
     >>> from ipyautoui.test_schema import TestAutoLogic
     >>> import ipywidgets as w
     >>> sch = TestAutoLogic.schema()["properties"]['int_slider']
@@ -175,6 +178,17 @@ class Combobox(w.Combobox):
 
 
 class Dropdown(w.Dropdown):
+    """extends `ipywidgets.Dropdown`. Example:
+    >>> from ipyautoui.demo_schemas import CoreIpywidgets
+    >>> import ipywidgets as w
+    >>> sch = CoreIpywidgets.schema()["properties"]['dropdown']
+    >>> Dropdown(sch).value
+
+    >>> sch = CoreIpywidgets.schema()["properties"]['dropdown_edge_case']
+    >>> Dropdown(sch).value
+
+    """
+
     def __init__(self, schema):
         self.schema = schema
         self.caller = create_widget_caller(schema)

--- a/src/ipyautoui/custom/decision_branch.py
+++ b/src/ipyautoui/custom/decision_branch.py
@@ -35,7 +35,7 @@ class TreeModel(BaseModel):
     description: str = ""
     options: list
     value: ty.Union[str, float, int] = None  # ty.Union[str, float, int]
-    children: ty.Union[TreeModel] = None
+    children: ty.ForwardRef("TreeModel") = None
     disabled: bool = False
     placeholder: str = ""
 
@@ -109,7 +109,7 @@ class DecisionUi(w.HBox):
 
 
 if __name__ == "__main__":
-
+    PROJECTS = ["J5001", "J5002"]
     t = TreeModel(
         **{
             "options": PROJECTS,
@@ -129,3 +129,5 @@ if __name__ == "__main__":
 if __name__ == "__main__":
     ui.value = ["J0001", "Calcs", "WUFI"]
     ui.disabled = [False, False, True]
+
+

--- a/src/ipyautoui/custom/editgrid.py
+++ b/src/ipyautoui/custom/editgrid.py
@@ -1249,13 +1249,12 @@ if __name__ == "__main__":
     editgrid.observe(lambda c: print("_value changed"), "_value")
     display(editgrid)
 
-CoreIpywidgets.schema()
-
 if __name__ == "__main__":
     from ipyautoui.demo_schemas import CoreIpywidgets
     from ipyautoui.autoipywidget import AutoObject
 
     # AutoObject(schema=CoreIpywidgets)
+    # TODO: fix this
 
     class TestDataFrameOnly(BaseModel):
         """a description of TestDataFrame"""
@@ -1333,5 +1332,4 @@ if __name__ == "__main__":
     ui.di_widgets["__root__"].observe(lambda c: print("grid _value change"), "_value")
     display(ui)
 
-# +
-# ui.value
+

--- a/src/ipyautoui/custom/editgrid.py
+++ b/src/ipyautoui/custom/editgrid.py
@@ -22,19 +22,22 @@
 # %load_ext lab_black
 import traitlets as tr
 import typing as ty
+import logging
 import traceback
 import pandas as pd
 import ipywidgets as w
-from typing import List
+from IPython.display import clear_output
 from markdown import markdown
 from pydantic import BaseModel, Field
 from ipydatagrid import CellRenderer, DataGrid, TextRenderer
 from ipydatagrid.datagrid import SelectionHelper
+
 import ipyautoui.autoipywidget as aui
 import ipyautoui.custom.save_buttonbar as sb
-from ipyautoui._utils import obj_from_importstr
-import logging
+from ipyautoui._utils import obj_from_importstr, frozenmap
+from ipyautoui.constants import BUTTON_WIDTH_MIN
 
+MAP_TRANSPOSED_SELECTION_MODE = frozenmap({True: "column", False: "row"})
 # TODO: rename "add" to "fn_add" so not ambiguous...
 
 # +
@@ -183,7 +186,7 @@ def try_getattr(obj, name):
     except:
         pass
 
-
+# TODO: create an AutoUiSchema class to handle schema gen and then extend it here...
 class GridSchema:
     def __init__(self, schema, get_traits=None, **kwargs):
         self.schema = schema
@@ -261,6 +264,14 @@ class GridSchema:
     @property
     def properties(self):
         return get_grid_column_properties_from_schema(self.schema)
+
+    @property
+    def property_keys(self):
+        return self.properties.keys()
+
+    @property
+    def property_titles(self):
+        return [p["title"] for p in self.properties.values()]
 
 
 # -
@@ -346,6 +357,7 @@ class AutoGrid(DataGrid):
     """
 
     schema = tr.Dict()
+    transposed = tr.Bool(default_value=False)
 
     @tr.observe("schema")
     def _update_from_schema(self, change):
@@ -364,6 +376,36 @@ class AutoGrid(DataGrid):
         else:
             raise tr.TraitError('schema must be of of type == "array"')
 
+    @tr.observe("transposed")
+    def _transposed(self, change):
+
+        self.selection_mode = MAP_TRANSPOSED_SELECTION_MODE[change["new"]]
+        self.data = self.data.T
+        # TODO: add hack to allow for the setting of layout on change here...
+
+    @property
+    def is_transposed(self):
+        if self.by_title:
+            cols_check = self.gridschema.property_titles
+        else:
+            cols_check = self.gridschema.property_keys
+        if set(cols_check) == set(self.column_names):
+            print(f"{str(cols_check)} == {str(set(self.column_names))}")
+            return False
+        else:
+            print(f"{str(cols_check)} != {str(set(self.column_names))}")
+            return True
+
+    def records(self, keys_as_title=False):
+        if self.transposed:
+            data = self.data.T
+        else:
+            data = self.data
+        if keys_as_title:
+            return data.to_dict(orient="records")
+        else:
+            return data.rename(columns=self.map_title_name).to_dict(orient="records")
+
     def __init__(
         self,
         schema: ty.Union[dict, ty.Type[BaseModel]],
@@ -375,8 +417,7 @@ class AutoGrid(DataGrid):
         # accept schema or pydantic schema
         self.kwargs = kwargs
         self.by_title = by_title
-        self.selection_mode = "column"
-
+        self.selection_mode = MAP_TRANSPOSED_SELECTION_MODE[self.transposed]
         self.model, self.schema = aui._init_model_schema(schema, by_alias=by_alias)
         data = self._init_data(data)
         super().__init__(data)
@@ -390,16 +431,6 @@ class AutoGrid(DataGrid):
             ]
         assert self.count_changes == 0
         # ^ this sets the default value and initiates change observer
-
-    def records(self, keys_as_title=False, transposed=False):
-        if transposed:
-            data = self.data.T
-        else:
-            data = self.data
-        if keys_as_title:
-            return data.to_dict(orient="records")
-        else:
-            return data.rename(columns=self.map_title_name).to_dict(orient="records")
 
     @property
     def default_row(self):
@@ -429,7 +460,7 @@ class AutoGrid(DataGrid):
 
     @property
     def index_names(self):
-        pass
+        pass # TODO: add this?
 
     @property
     def column_names(self):
@@ -452,26 +483,43 @@ class AutoGrid(DataGrid):
         else:
             return self.map_titles_to_data(data)
 
-    def set_row_value(self, key: int, value: dict):
+    def set_item_value(self, index: int, value: dict):
+        """
+        set row (transposed==False) or col (transposed==True) value
+        """
+        if self.transposed:
+            self.set_col_value(index, value)
+        else:
+            self.set_row_value(index, value)
+
+    def set_row_value(self, index: int, value: dict):
         """Set a chosen row using the key and a value given.
 
         Note: We do not call value setter to apply values as it resets the datagrid.
 
         Args:
-            key (int): The key of the row. # TODO: is this defo an int?
+            index (int): The key of the row. # TODO: is this defo an int?
             value (dict): The data we want to input into the row.
         """
         if set(value.keys()) == set(self.map_name_title.keys()):
             # value_with_titles is used for datagrid
             value = {self.map_name_title.get(name): v for name, v in value.items()}
+            # ^ self.apply_map_name_title(value)  ? ??
         elif set(value.keys()) == set(self.map_name_title.values()):
             pass
         else:
             raise Exception("Columns of value given do not match with value keys.")
         for column, v in value.items():
-            self.set_cell_value(column, key, v)
+            self.set_cell_value(column, index, v)
 
-    def set_col_value(self, column_name: ty.Any, value: dict):
+    def apply_map_name_title(self, row_data):
+        return {
+            self.map_title_name[k]: v
+            for k, v in row_data.items()
+            if k in self.map_title_name.keys()
+        }
+
+    def set_col_value(self, index: int, value: dict):
         """Set a chosen col using the key and a value given.
 
         Note: We do not call value setter to apply values as it resets the datagrid.
@@ -480,14 +528,10 @@ class AutoGrid(DataGrid):
             key (int): The key of the col
             value (dict): The data we want to input into the col.
         """
-        if column_name not in self.column_names:
-            try:
-                column_name = self.map_name_title.get(column_name)
-            except:
-                raise ValueError(
-                    f"`column_name` = {column_name} does not exist in datagrid."
-                )
-
+        column_name = self.get_col_name_from_index(index)
+        if set(value.keys()) == set(self.map_name_title.keys()):
+            # value_with_titles is used for datagrid
+            value = {self.map_name_title.get(name): v for name, v in value.items()}
         if set(value.keys()) != set(self.data.index.to_list()):
             raise Exception("Index of datagrid does not match with value keys.")
         for primary_key_value, v in value.items():
@@ -546,11 +590,11 @@ class AutoGrid(DataGrid):
             raise Exception("Can't move up first row.")
         self._swap_rows(key_a=key, key_b=key - 1)
 
-    def _move_rows_up(self, li_keys: List[int]):
+    def _move_rows_up(self, li_keys: ty.List[int]):
         """Move multiple rows up.
 
         Args:
-            li_key (List[int]): List of row keys.
+            li_key (ty.List[int]): ty.List of row keys.
         """
         if is_incremental(sorted(li_keys)) is False:
             raise Exception("Only select a property or block of properties.")
@@ -560,11 +604,11 @@ class AutoGrid(DataGrid):
             {"r1": min(li_keys) - 1, "r2": max(li_keys) - 1, "c1": 0, "c2": 2}
         ]
 
-    def _move_rows_down(self, li_keys: List[int]):
+    def _move_rows_down(self, li_keys: ty.List[int]):
         """Move multiple rows down.
 
         Args:
-            li_key (List[int]): List of row keys.
+            li_key (ty.List[int]): ty.List of row keys.
         """
         if is_incremental(sorted(li_keys)) is False:
             raise Exception("Only select a property or block of properties.")
@@ -596,12 +640,36 @@ class AutoGrid(DataGrid):
 
         return SelectionHelper(view_data_object, self.selections, self.selection_mode)
 
-    def apply_map_name_title(self, row_data):
-        return {
-            self.map_title_name[k]: v
-            for k, v in row_data.items()
-            if k in self.map_title_name.keys()
-        }
+    # these terms (below) avoid row or col terminology and can be used if transposed or not...
+    # only these methods are called be EditGrid, allowing it to operate the same if the 
+    # view is transposed or not.
+    # ----------
+    @property
+    def selected(self):
+        if self.transposed:
+            return self.selected_col
+        else:
+            return self.selected_row
+
+    @property
+    def selected_items(self):
+        if self.transposed:
+            return self.selected_cols
+        else:
+            return self.selected_rows
+
+    @property
+    def selected_index(self):
+        return self.selected_indexes[0]
+
+    @property
+    def selected_indexes(self):
+        if self.transposed:
+            return self.selected_col_indexes
+        else:
+            return self.selected_row_indexes
+
+    # ----------
 
     @property
     def selected_row(self):
@@ -630,13 +698,12 @@ class AutoGrid(DataGrid):
     def selected_cols(self):
         """Get the data selected in the table which is returned as a dataframe."""
         s = self.selected_visible_cell_iterator
-
-        s = self.selected_visible_cell_iterator
-        row_index = self.get_dataframe_index(grid.data)
         cols = set([l["c"] for l in s])
-        cols = [grid.get_col_name_from_index(col_index) for col_index in cols]
+        cols = [self.get_col_name_from_index(col_index) for col_index in cols]
+        index = self.get_dataframe_index(self.data)
         return [
-            {l[row_index]: l[col_name] for l in s._data["data"]} for col_name in cols
+            self.apply_map_name_title({l[index]: l[col_name] for l in s._data["data"]})
+            for col_name in cols
         ]
 
     @property
@@ -653,19 +720,25 @@ class AutoGrid(DataGrid):
         index = self.get_dataframe_index(self.data)
         rows = set([l["r"] for l in s])
         return [s._data["data"][r][index] for r in rows]
-    
-    @property
-    def selected_indexes(self):
-        """Return the keys of the selected rows. still works if transform applied."""
-        s = self.selected_visible_cell_iterator
-        index = self.get_dataframe_index(self.data)
-        cols = set([l["c"] for l in s])
-        return [s._data["data"][c][index] for c in cols]
 
     @property
-    def selected_rows_dict(self):
+    def selected_col_index(self):
+        """returns the first."""
+        return self.selected_col_indexes[0]
+
+    @property
+    def selected_col_indexes(self):
+        """Return the keys of the selected rows. still works if transform applied."""
+        s = self.selected_visible_cell_iterator
+        return list(set([l["c"] for l in s]))
+
+    @property
+    def selected_dict(self):
         """Return the dictionary of selected rows where key is row index. still works if transform applied."""
-        return self.data.loc[self.selected_row_indexes].to_dict("index")
+        if self.transposed:
+            return self.data.T.loc[self.selected_col_indexes].to_dict("index")
+        else:
+            return self.data.loc[self.selected_row_indexes].to_dict("index")
 
     # ----------------
 
@@ -696,6 +769,15 @@ if __name__ == "__main__":
 
 
 if __name__ == "__main__":
+    grid.data = pd.DataFrame(grid.data.to_dict(orient="records") * 4)  # .T
+
+if __name__ == "__main__":
+    print(grid.is_transposed)
+
+if __name__ == "__main__":
+    grid.transposed = False
+
+if __name__ == "__main__":
     # test pd.to_dict
     df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
     display(df)
@@ -706,9 +788,6 @@ if __name__ == "__main__":
     print(df.to_dict(orient="split"))
     print(df.to_dict(orient="records"))
     print(df.to_dict(orient="index"))
-
-if __name__ == "__main__":
-    grid.data = pd.DataFrame(grid.data.to_dict(orient="records") * 4)  # .T
 
 if __name__ == "__main__":
     print(grid.count_changes)
@@ -761,10 +840,6 @@ class RowEditor:
 
 
 # +
-from ipyautoui.constants import BUTTON_WIDTH_MIN
-from IPython.display import clear_output
-
-
 class UiDelete(w.HBox):
     value = tr.Dict(default_value={})
     columns = tr.List(allow_none=True, default_value=None)
@@ -838,11 +913,18 @@ if __name__ == "__main__":
 class EditGrid(w.VBox):
     _value = tr.Tuple()  # using a tuple to guarantee no accidental mutation
     warn_on_delete = tr.Bool()
-    display_transposed = tr.Bool(default_value=False)
 
     @property
     def value(self):
         return self._value
+
+    @property
+    def transposed(self):
+        return self.grid.transposed
+
+    @transposed.setter
+    def transposed(self, value: bool):
+        self.grid.transposed = value
 
     def _update_value_from_grid(self):
         # print(self._value)  # old
@@ -854,15 +936,10 @@ class EditGrid(w.VBox):
         if value == [] or value is None:
             self.grid.data = self.grid.get_default_data()
         else:
-            df = pd.DataFrame(value)
-            self.grid.data = self.grid.map_titles_to_data(df)
-            
-    @property
-    def selected(self):
-        if self.display_transposed:
-            return self.grid.selected_cols
-        else:
-            return self.grid.selected_rows
+            df = self.grid._init_data(pd.DataFrame(value))
+            if self.transposed:
+                df = df.T
+            self.grid.data = df  # self.grid.map_titles_to_data(df)
 
     def __init__(
         self,
@@ -982,7 +1059,7 @@ class EditGrid(w.VBox):
         self.buttonbar_grid.delete.value = False
 
     def _check_one_row_selected(self):
-        if len(self.grid.selected_row_indexes) > 1:
+        if len(self.grid.selected_indexes) > 1:
             raise Exception(
                 markdown("  👇 _Please only select ONLY one row from the table!_")
             )
@@ -990,16 +1067,16 @@ class EditGrid(w.VBox):
     # edit row
     # --------------------------------------------------------------------------
     def _validate_edit_click(self):
-        if len(self.grid.selected_row_indexes) == 0:
+        if len(self.grid.selected_indexes) == 0:
             raise ValueError("you must select a row")
         self._check_one_row_selected()
 
     def _save_edit_to_grid(self):
-        self.grid.set_row_value(self.grid.selected_row_index, self.ui_edit.value)
+        self.grid.set_item_value(self.grid.selected_index, self.ui_edit.value)
         self.setview_default()
 
     def _set_ui_edit_to_selected_row(self):
-        self.ui_edit.value = self.grid.selected_row
+        self.ui_edit.value = self.grid.selected
         self.ui_edit.savebuttonbar.unsaved_changes = False
 
     def _patch(self):
@@ -1062,13 +1139,14 @@ class EditGrid(w.VBox):
     # --------------------------------------------------------------------------
     def _copy(self):
         try:
-            if self.grid.selected_row_indexes == []:
+            if self.grid.selected_indexes == []:
                 self.buttonbar_grid.message.value = markdown(
                     "  👇 _Please select a row from the table!_ "
                 )
             else:
                 li_values_selected = [
-                    self.value[i] for i in sorted([i for i in self.grid.selected_row_indexes])
+                    self.value[i]
+                    for i in sorted([i for i in self.grid.selected_indexes])
                 ]
                 if self.fn_on_copy is not None:
                     li_values_selected = self.fn_on_copy(li_values_selected)
@@ -1098,7 +1176,7 @@ class EditGrid(w.VBox):
 
     def _delete_selected(self):
         if self.datahandler is not None:
-            value = [self.value[i] for i in self.grid.selected_row_indexes]
+            value = [self.value[i] for i in self.grid.selected_indexes]
             for v in value:
                 self.datahandler.fn_delete(v)
             self._reload_all_data()
@@ -1106,23 +1184,23 @@ class EditGrid(w.VBox):
             self.value = [
                 value
                 for i, value in enumerate(self.value)
-                if i not in self.grid.selected_row_indexes
+                if i not in self.grid.selected_indexes
             ]
-            # ^ Only set for values NOT in self.grid.selected_row_indexes
+            # ^ Only set for values NOT in self.grid.selected_indexes
         self.buttonbar_grid.message.value = markdown("  🗑️ _Deleted Row_ ")
         self.buttonbar_grid.delete.value = False
 
     def _set_ui_delete_to_selected_row(self):
-        self.ui_delete.value = self.grid.selected_rows_dict
+        self.ui_delete.value = self.grid.selected_dict
 
     def _delete(self):
         try:
-            if len(self.grid.selected_row_indexes) > 0:
-                print(f"Row Number: {self.grid.selected_row_indexes}")
+            if len(self.grid.selected_indexes) > 0:
+                print(f"Row Number: {self.grid.selected_indexes}")
                 if not self.warn_on_delete:
                     self._delete_selected()
                 else:
-                    self.ui_delete.value = self.grid.selected_rows_dict
+                    self.ui_delete.value = self.grid.selected_dict
                     self.setview_delete()
             else:
                 self.buttonbar_grid.delete.value = False
@@ -1133,7 +1211,6 @@ class EditGrid(w.VBox):
             traceback.print_exc()
 
 
-
 if __name__ == "__main__":
     AUTO_GRID_DEFAULT_VALUE = [
         {
@@ -1141,15 +1218,8 @@ if __name__ == "__main__":
             "integer": 1,
             "floater": 3.14,
         },
-        # {
-        #     "string": "update",
-        #     "integer": 4,
-        #     "floater": 3.12344,
-        # },
-        # {"string": "evening", "integer": 5, "floater": 3.14},
-        # {"string": "morning", "integer": 5, "floater": 3.14},
-        # {"string": "number", "integer": 3, "floater": 3.14},
     ]
+    AUTO_GRID_DEFAULT_VALUE = AUTO_GRID_DEFAULT_VALUE * 4
 
     class DataFrameCols(BaseModel):
         string: str = Field("string", column_width=100)
@@ -1177,7 +1247,68 @@ if __name__ == "__main__":
     editgrid.observe(lambda c: print("_value changed"), "_value")
     display(editgrid)
 
+if __name__ == "__main__":
+    from ipyautoui.demo_schemas import CoreIpywidgets
+    from ipyautoui.autoipywidget import AutoObject
 
+    # AutoObject(schema=CoreIpywidgets)
+
+    class TestDataFrameOnly(BaseModel):
+        """a description of TestDataFrame"""
+
+        __root__: ty.List[CoreIpywidgets] = Field(
+            [CoreIpywidgets().dict()], format="dataframe"
+        )
+
+    description = markdown(
+        "<b>The Wonderful Edit Grid Application</b><br>Useful for all editing purposes"
+        " whatever they may be 👍"
+    )
+    editgrid = EditGrid(
+        schema=TestDataFrameOnly,
+        description=description,
+        ui_add=None,
+        ui_edit=None,
+        warn_on_delete=True,
+    )
+    editgrid.observe(lambda c: print("_value changed"), "_value")
+    display(editgrid)
+
+# + active=""
+# s = editgrid.grid.selected_visible_cell_iterator
+# cols = set([l["c"] for l in s])
+# cols = [editgrid.grid.get_col_name_from_index(col_index) for col_index in cols]
+# index = editgrid.grid.get_dataframe_index(editgrid.grid.data)
+# [
+#     editgrid.grid.apply_map_name_title({l[index]: l[col_name] for l in s._data["data"]})
+#     for col_name in cols
+# ]
+
+# + active=""
+# editgrid.grid.selected_index
+
+# + active=""
+# editgrid.grid.data.index.to_list()
+
+# + active=""
+# editgrid.ui_edit.value
+
+# + active=""
+# editgrid.value = [
+#     value
+#     for i, value in enumerate(editgrid.value)
+#     if i not in editgrid.grid.selected_indexes
+# ]
+
+# + active=""
+# editgrid.ui_edit.value
+
+# + active=""
+# editgrid.grid.selected_index
+# -
+
+if __name__ == "__main__":
+    editgrid.transposed = True
 
 if __name__ == "__main__":
 

--- a/src/ipyautoui/custom/editgrid.py
+++ b/src/ipyautoui/custom/editgrid.py
@@ -20,6 +20,7 @@
 # %run __init__.py
 # %run ../__init__.py
 # %load_ext lab_black
+# TODO: move editgrid.py to root
 import traitlets as tr
 import typing as ty
 import logging
@@ -185,6 +186,7 @@ def try_getattr(obj, name):
         return getattr(obj, name)
     except:
         pass
+
 
 # TODO: create an AutoUiSchema class to handle schema gen and then extend it here...
 class GridSchema:
@@ -460,7 +462,7 @@ class AutoGrid(DataGrid):
 
     @property
     def index_names(self):
-        pass # TODO: add this?
+        pass  # TODO: add this?
 
     @property
     def column_names(self):
@@ -641,7 +643,7 @@ class AutoGrid(DataGrid):
         return SelectionHelper(view_data_object, self.selections, self.selection_mode)
 
     # these terms (below) avoid row or col terminology and can be used if transposed or not...
-    # only these methods are called be EditGrid, allowing it to operate the same if the 
+    # only these methods are called be EditGrid, allowing it to operate the same if the
     # view is transposed or not.
     # ----------
     @property
@@ -1246,6 +1248,8 @@ if __name__ == "__main__":
     )
     editgrid.observe(lambda c: print("_value changed"), "_value")
     display(editgrid)
+
+CoreIpywidgets.schema()
 
 if __name__ == "__main__":
     from ipyautoui.demo_schemas import CoreIpywidgets

--- a/src/ipyautoui/custom/iterable.py
+++ b/src/ipyautoui/custom/iterable.py
@@ -70,6 +70,7 @@ Example:
         display(arr)
 
 """
+# TODO: move iterable.py to root
 # TODO: review: https://github.com/widgetti/react-ipywidgets - it could simplify the code required below.
 # %run __init__.py
 # %load_ext lab_black

--- a/src/ipyautoui/demo_schemas/core_ipywidgets.py
+++ b/src/ipyautoui/demo_schemas/core_ipywidgets.py
@@ -10,7 +10,7 @@ from pathlib import PurePosixPath
 
 
 class FruitEnum(str, Enum):
-    """available genders. this is just an example."""
+    """fruit example."""
 
     apple = "apple"
     pear = "pear"
@@ -33,7 +33,9 @@ class CoreIpywidgets(BaseModel):
     checkbox: bool = True
     dropdown: FruitEnum = None
     dropdown_edge_case: FruitEnum = Field(
-        default=FruitEnum.apple, description="updated description"
+        title="FruitEnum with metadata",
+        default=FruitEnum.apple,
+        description="updated description",
     )
     dropdown_simple: str = Field(default="asd", enum=["asd", "asdf"])
     text: str = Field(default="adsf", description="a description about my string")

--- a/tests/test_autoui.py
+++ b/tests/test_autoui.py
@@ -11,20 +11,35 @@ import pathlib
 # from ipyautoui.tests import test_display_widget_mapping
 from .constants import DIR_TESTS, DIR_FILETYPES
 from .example_objects import ExampleSchema
-from ipyautoui import AutoUi, AutoDisplay, AutoVjsf
-from ipyautoui.autoipywidget import AutoObject
+from ipyautoui import AutoUi
+from ipyautoui.demo_schemas import CoreIpywidgets
+from ipyautoui.basemodel import file
+import json
+import pytest
 
-DIR_TEST_DATA = DIR_TESTS / "test_data"
+DIR_TEST_DATA = DIR_TESTS / "testdata"
 DIR_TEST_DATA.mkdir(parents=True, exist_ok=True)
-shutil.rmtree(
-    DIR_TEST_DATA
-)  #  remove previous data. this allows tests to check if files exist.
+
+value_default = json.loads(CoreIpywidgets().json())
+PATH_TEST_AUTO_READ_FILE = DIR_TEST_DATA / "test_auto_read_file.json"
+PATH_TEST_AUTO_READ_FILE.unlink(missing_ok=True)
+changed = CoreIpywidgets(text="changed")
+value_changed = json.loads(changed.json())
+file(changed, PATH_TEST_AUTO_READ_FILE)
 
 
 class TestAutoUi:
+    @pytest.mark.skip(
+        reason="this fails, as widgets auto sets the value...? TODO: resovle."
+    )
     def test_auto_ui(self):
-        ui = AutoUi(ExampleSchema)
-        assert ui.value == {"text": "Test"}
+        ui = AutoUi(CoreIpywidgets)
+        assert ui.value == value_default
+        print("done")
+
+    def test_auto_read_file(self):
+        ui = AutoUi(CoreIpywidgets, path=PATH_TEST_AUTO_READ_FILE)
+        assert ui.value["text"] == value_changed["text"]
         print("done")
 
     # def test_display_file(self):

--- a/tests/testdata/test_auto_read_file.json
+++ b/tests/testdata/test_auto_read_file.json
@@ -1,0 +1,22 @@
+{
+    "int_slider": 2,
+    "int_text": 1,
+    "int_range_slider": [
+        0,
+        3
+    ],
+    "float_slider": 2.2,
+    "float_text": 2.2,
+    "float_text_locked": 2.2,
+    "float_range_slider": [
+        0,
+        2.2
+    ],
+    "checkbox": true,
+    "dropdown": null,
+    "dropdown_edge_case": null,
+    "dropdown_simple": "asd",
+    "text": "changed",
+    "text_short": "short text",
+    "text_area": "long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text long text "
+}

--- a/tests/testdata/test_auto_read_file.json
+++ b/tests/testdata/test_auto_read_file.json
@@ -14,7 +14,7 @@
     ],
     "checkbox": true,
     "dropdown": null,
-    "dropdown_edge_case": null,
+    "dropdown_edge_case": "apple",
     "dropdown_simple": "asd",
     "text": "changed",
     "text_short": "short text",


### PR DESCRIPTION
PR adds the `transposed` trait to `custom.editgrid.DataGrid` which transposes the UI view of the DataGrid.
NOTE:
- it does not change the `_value` of the AutoGrid trait, it is intended to allow for a different UI based on the same data
TODO:
- add UI button to toggle between transposed / not transposed view
- define how the formatting gets set / reset when toggling between the views