### PR TITLE
Autogrid records issue

### DIFF
--- a/src/ipyautoui/custom/autogrid.py
+++ b/src/ipyautoui/custom/autogrid.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.14.4
+#       jupytext_version: 1.14.5
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -72,7 +72,8 @@ def get_default_row_data_from_schema_properties(
 
 
 def get_column_widths_from_schema(schema, column_properties, map_name_index, **kwargs):
-    """Set the column widths of the data grid based on column_width given in the schema."""
+    """Set the column widths of the data grid based on column_width given in the schema.
+    """
 
     # start with settings in properties
     column_widths = {
@@ -654,7 +655,9 @@ class AutoGrid(DataGrid):
         if keys_as_title:
             return data.to_dict(orient="records")
         else:
-            data.columns = self.gridschema.property_keys
+            data.columns = [
+                self.gridschema.map_index_name.get(name) for name in data.columns
+            ]
             return data.to_dict(orient="records")
 
     def __init__(
@@ -1034,7 +1037,8 @@ class AutoGrid(DataGrid):
 
     @property
     def selected_dict(self):
-        """Return the dictionary of selected rows where index is row index. still works if transform applied."""
+        """Return the dictionary of selected rows where index is row index. still works if transform applied.
+        """
         if self.transposed:
             return self.data.T.loc[self.selected_col_indexes].to_dict("index")
         else:

--- a/tests/test_autogrid.py
+++ b/tests/test_autogrid.py
@@ -199,9 +199,6 @@ class TestGridSchema:
         assert data.equals(df_check)
         assert gridschema.coerce_data(df, transposed=True).equals(df_check.T)
 
-        print("done")
-        # assert data == pd.DataFrame.
-
     def test_coerce_data_from_incomplete(self):
         class TestProperties(BaseModel):
             string: str
@@ -228,7 +225,6 @@ class TestGridSchema:
                 "properties"
             ].values()
         ]
-        print("done")
 
 
 class TestAutoGrid:
@@ -305,7 +301,6 @@ class TestAutoGrid:
         assert grid4._data["data"] == [
             {"index": 0, "String": "test2", "Floater": 2.2, "ipydguuid": 0}
         ]
-        print("done")
 
     def test_reset_multiindex_data_with_init_data(self):
         # get default data passed as kwarg, keys as column headers. maps to titles
@@ -361,10 +356,11 @@ class TestAutoGrid:
         df = gr._init_data(
             pd.DataFrame([{"string": "test2", "floater": 2.2, "inty": 1}])
         )
-        print("done")
 
     @pytest.mark.parametrize("transposed", [True, False])
     def test_order_index(self, transposed: bool):
+        """Test that the order works"""
+
         class Cols(BaseModel):
             string: str = Field(aui_column_width=100)
             floater: float = Field(aui_column_width=70, aui_sig_fig=3)
@@ -410,6 +406,8 @@ class TestAutoGrid:
 
     @pytest.mark.parametrize("transposed", [True, False])
     def test_order_multi_index(self, transposed: bool):
+        """Test order with multi index"""
+
         class Cols(BaseModel):
             string: str = Field(aui_column_width=100, title="String", section="a")
             floater: float = Field(
@@ -456,6 +454,9 @@ class TestAutoGrid:
 
     @pytest.mark.parametrize("transposed", [True, False])
     def test_order_index_with_strict_subset(self, transposed: bool):
+        """Test that the order is applied to the data even if the order is a strict subset of the data columns
+        """
+
         class Cols(BaseModel):
             string: str = Field(aui_column_width=100)
             floater: float = Field(aui_column_width=70, aui_sig_fig=3)
@@ -502,6 +503,8 @@ class TestAutoGrid:
 
     @pytest.mark.parametrize("transposed", [True, False])
     def test_order_multi_index_with_strict_subset(self, transposed: bool):
+        """Test that order works with multi-index and strict subset of columns"""
+
         class Cols(BaseModel):
             string: str = Field(aui_column_width=100, title="String", section="a")
             floater: float = Field(

--- a/tests/test_autogrid.py
+++ b/tests/test_autogrid.py
@@ -231,7 +231,7 @@ class TestGridSchema:
         print("done")
 
 
-class TestAutoGridInitData:
+class TestAutoGrid:
     def test_empty_grid(self):
         class Cols(BaseModel):
             string: str = Field(aui_column_width=100)
@@ -453,3 +453,117 @@ class TestAutoGridInitData:
                 [grid_with_data.map_name_index.get(name) for name in order]
             )
             assert di_grid_with_data_before_order == grid_with_data.data.to_dict()
+
+    @pytest.mark.parametrize("transposed", [True, False])
+    def test_order_index_with_strict_subset(self, transposed: bool):
+        class Cols(BaseModel):
+            string: str = Field(aui_column_width=100)
+            floater: float = Field(aui_column_width=70, aui_sig_fig=3)
+
+        class DataFrameSchema(BaseModel):
+            """no default"""
+
+            __root__: ty.List[Cols] = Field(format="dataframe")
+
+        order = ("floater",)
+        # Test without data passed
+        grid_without_data = AutoGrid(
+            schema=DataFrameSchema, transposed=transposed, order=order
+        )
+        # Test with data passed
+        data = pd.DataFrame([Cols(string="test", floater=2.5).dict()])
+        grid_with_data = AutoGrid(
+            schema=DataFrameSchema,
+            data=data,
+            transposed=transposed,
+        )
+        di_grid_with_data_before_order = grid_with_data.data.to_dict()
+        grid_with_data.order = order
+        if transposed:
+            assert tuple(grid_without_data.data.index) == tuple(
+                [grid_without_data.map_name_index.get(name) for name in order]
+            )
+            assert tuple(grid_with_data.data.index) == tuple(
+                [grid_with_data.map_name_index.get(name) for name in order]
+            )
+            assert di_grid_with_data_before_order.get(
+                "Floater"
+            ) == grid_with_data.data.to_dict().get("Floater")
+        else:
+            assert tuple(grid_without_data.data.columns) == tuple(
+                [grid_without_data.map_name_index.get(name) for name in order]
+            )
+            assert tuple(grid_with_data.data.columns) == tuple(
+                [grid_with_data.map_name_index.get(name) for name in order]
+            )
+            assert di_grid_with_data_before_order.get(
+                "Floater"
+            ) == grid_with_data.data.to_dict().get("Floater")
+
+    @pytest.mark.parametrize("transposed", [True, False])
+    def test_order_multi_index_with_strict_subset(self, transposed: bool):
+        class Cols(BaseModel):
+            string: str = Field(aui_column_width=100, title="String", section="a")
+            floater: float = Field(
+                aui_column_width=70, aui_sig_fig=3, title="Floater", section="a"
+            )
+
+        class DataFrameSchema(BaseModel):
+            """no default"""
+
+            __root__: ty.List[Cols] = Field(
+                format="dataframe",
+                datagrid_index_name=("section", "title"),
+            )
+
+        order = ("floater",)
+        # Test without data passed
+        grid_without_data = AutoGrid(schema=DataFrameSchema, order=order)
+        # Test with data passed
+        data = pd.DataFrame([Cols(string="test", floater=2.5).dict()])
+        grid_with_data = AutoGrid(
+            schema=DataFrameSchema,
+            data=data,
+            transposed=transposed,
+        )
+        di_grid_with_data_before_order = grid_with_data.data.to_dict()
+        grid_with_data.order = order
+        if transposed is True:
+            assert tuple(grid_without_data.data.index) == ()
+            assert tuple(grid_with_data.data.index) == tuple(
+                [grid_with_data.map_name_index.get(name) for name in order]
+            )
+            assert di_grid_with_data_before_order.get(
+                ("a", "Floater")
+            ) == grid_with_data.data.to_dict().get(("a", "Floater"))
+        else:
+            assert tuple(grid_without_data.data.columns) == tuple(
+                [grid_without_data.map_name_index.get(name) for name in order]
+            )
+            assert tuple(grid_with_data.data.columns) == tuple(
+                [grid_with_data.map_name_index.get(name) for name in order]
+            )
+            assert di_grid_with_data_before_order.get(
+                ("a", "Floater")
+            ) == grid_with_data.data.to_dict().get(("a", "Floater"))
+
+    def test_records(self):
+        """Test records method of AutoGrid. Also test that re-ordering indexes
+        works correctly."""
+
+        class Cols(BaseModel):
+            string: str = Field(aui_column_width=100)
+            floater: float = Field(aui_column_width=70, aui_sig_fig=3)
+
+        class DataFrameSchema(BaseModel):
+            """no default"""
+
+            __root__: ty.List[Cols] = Field(format="dataframe")
+
+        data = pd.DataFrame([Cols(string="test", floater=2.5).dict()])
+        grid = AutoGrid(schema=DataFrameSchema, data=data)
+        assert grid.records() == [{"string": "test", "floater": 2.5}]
+        grid.order = ("floater", "string")
+        assert grid.records() == [{"floater": 2.5, "string": "test"}]
+        grid.order = ("floater",)
+        assert grid.records() == [{"floater": 2.5}]


### PR DESCRIPTION
🐛 Updated `records` AutoGrid method to return correct data after reordering of indexes.
✅ 3 new tests added to check `records` AutoGrid method, and that a strict subset of indexes can be passed to the AutoGrid `order` traitlet i.e. `("floater",)` can be passed to AutoGrid's `order` where the grid has 2 indexes: "floater", and "string".