### PR TITLE
Override nullable UI

### DIFF
--- a/src/ipyautoui/automapschema.py
+++ b/src/ipyautoui/automapschema.py
@@ -586,7 +586,13 @@ def widgetcaller(caller: WidgetCaller, show_errors=True):
     """
     try:
         if "nullable" in caller.schema_.keys() and caller.schema_["nullable"]:
-            fn = auiwidgets.nullable(caller.autoui)
+            if (
+                "override_nullable_ui" in caller.schema_.keys()
+                and caller.schema_["override_nullable_ui"]
+            ):
+                fn = caller.autoui
+            else:
+                fn = auiwidgets.nullable(caller.autoui)
         else:
             fn = caller.autoui
         wi = fn(caller.schema_, *caller.args, **caller.kwargs)

--- a/src/ipyautoui/demo_schemas/nullable_core_ipywidgets.py
+++ b/src/ipyautoui/demo_schemas/nullable_core_ipywidgets.py
@@ -40,6 +40,18 @@ class NullableCoreIpywidgets(BaseModel):
     dropdown_simple: str = Field(default=None, enum=["asd", "asdf"])
     text: str = Field(default=None, description="a description about my string")
     text_short: constr(min_length=0, max_length=20) = None
-    text_area: constr(min_length=0, max_length=800) = Field(None, description="long text field")
+    text_area: constr(min_length=0, max_length=800) = Field(
+        None, description="long text field"
+    )
 
 
+class OverrideNullableIpywidgets(BaseModel):
+    """If you want to override the default behavior of nullable fields, you can 
+    do so by setting the override_nullable_ui to True to prevent the Nullable UI
+    element from being generated.
+    """
+    text: str = Field(
+        default=None,
+        description="a description about my string",
+        override_nullable_ui=True,
+    )

--- a/tests/test_autoipywidget.py
+++ b/tests/test_autoipywidget.py
@@ -79,6 +79,18 @@ class TestAutoObject:
         assert ui.value == {"text": "Test"}
         print("done")
 
+    def test_simple_override_nullable_ui(self):
+        class ExampleSchema(BaseModel):
+            text: str = Field(
+                default=None,
+                description="This test is important",
+                override_nullable_ui=True,
+            )
+
+        auto_ui_eg = ExampleSchema()
+        ui = AutoObject(auto_ui_eg)
+        assert "Nullable" not in str(ui.di_widgets.get("text"))
+
     def test_dict_raises_error(self):
         class ExampleSchema(BaseModel):
             text: dict = Field(
@@ -87,8 +99,10 @@ class TestAutoObject:
 
         with pytest.raises(
             ValueError,
-            match="AutoUi does not support rendering generic dictionaries."
-            " This can be overridden by specifying a `autoui` pyobject renderer.",
+            match=(
+                "AutoUi does not support rendering generic dictionaries."
+                " This can be overridden by specifying a `autoui` pyobject renderer."
+            ),
         ):
             auto_ui_eg = ExampleSchema()
             ui = AutoObject(auto_ui_eg)


### PR DESCRIPTION
- Feature to be able to override the nullable UI element from being added.
- This can be done by adding `override_nullable_ui=True` to the field e.g.

```python
class Example(BaseModel):
    text: str = Field(
        default=None,
        description="a description about my string",
        override_nullable_ui=True,
    )
```