### PR TITLE
🐛-fix-value-watcher-for-nullable-arrays

### DIFF
--- a/src/ipyautoui/autowidgets.py
+++ b/src/ipyautoui/autowidgets.py
@@ -153,6 +153,7 @@ class Nullable(w.HBox):
     def _init_controls(self):
         self.bn.observe(self._toggle_none, "value")
         self.widget.observe(self._update, "value")
+        self.widget.observe(self._update, "_value")
         self.observe(self._observe_nullable, "nullable")
 
     def _observe_nullable(self, onchange):

--- a/src/ipyautoui/demo_schemas/nested.py
+++ b/src/ipyautoui/demo_schemas/nested.py
@@ -26,3 +26,5 @@ class Nested(BaseModel):
     recursive_nest: RecursiveNest
     array_simple: list[str]
     array_objects: list[NestedObject]
+    nullable_list: list[str] = None
+    nullable_object: NestedObject = None


### PR DESCRIPTION
simple fix - the `Nullable` widget wasn't watching `_value` trait so wasn't working with custom widgets