### PR TITLE
✨-generalise-autodisplay_rendererers

### DIFF
--- a/src/ipyautoui/_utils.py
+++ b/src/ipyautoui/_utils.py
@@ -442,3 +442,16 @@ def check_installed(package_name):
         return False
     else:
         return True
+
+def html_link(url: str, description: str, color: str="blue"):
+    """returns an html link string to open in new tab
+
+    Args:
+        url (url): 
+        description (str): the text to display for the link         
+        color (str, optional): color of description text. Defaults to "blue".
+
+    Returns:
+        str: html text
+    """
+    return f'<font color="{color}"><a href="{url}" target="blank" >{description}</a></font>'

--- a/src/ipyautoui/autodisplay_renderers.py
+++ b/src/ipyautoui/autodisplay_renderers.py
@@ -255,12 +255,26 @@ def xlsxtemplated_display(li):
         display(l["grid"])
 
 
-def preview_json(path: ty.Union[pathlib.Path, HttpUrl, ty.Callable]):
-    js = json.loads(getbytes(path).decode())
-    return Markdown(
+def preview_json_string(json_str):
+    Markdown(
         f"""
 ```json
-{json.dumps(js, indent=4)}
+{json.dumps(json_str, indent=4)}
+```
+"""
+    )
+
+
+def preview_json(path: ty.Union[pathlib.Path, HttpUrl, ty.Callable]):
+    js = json.loads(getbytes(path).decode())
+    return preview_json_string(js)
+
+
+def preview_yaml_string(yaml_str):
+    Markdown(
+        f"""
+```yaml
+{yaml_str}
 ```
 """
     )
@@ -268,22 +282,20 @@ def preview_json(path: ty.Union[pathlib.Path, HttpUrl, ty.Callable]):
 
 def preview_yaml(path: ty.Union[pathlib.Path, HttpUrl, ty.Callable]):
     byts = getbytes(path)
-    return Markdown(
-        f"""
-```yaml
-{byts.decode()}
-```
-"""
-    )
+    return preview_yaml_string(byts.decode())
+
+
+def preview_plotly_json(plotly_str):
+    package_name = "plotly"
+    if check_installed(package_name):
+        return pio.from_json(plotly_str)
+    else:
+        return w.HTML(package_name + " is not installed")
 
 
 def preview_plotly(path: ty.Union[pathlib.Path, HttpUrl, ty.Callable]):
-    package_name = "plotly"
-    if check_installed(package_name):
-        byts = getbytes(path)
-        return pio.from_json(byts.decode())
-    else:
-        return w.HTML(package_name + " is not installed")
+    byts = getbytes(path)
+    return preview_plotly_json(byts.decode())
 
 
 def Vega(spec):
@@ -344,9 +356,17 @@ def get_vega_data(path: ty.Union[pathlib.Path, HttpUrl, ty.Callable]):
     return data
 
 
+def preview_vega_json(vega_json):
+    return Vega(vega_json)
+
+
 def preview_vega(path: ty.Union[pathlib.Path, HttpUrl, ty.Callable]):
     data = get_vega_data(path)
-    return Vega(data)
+    return preview_vega_json(data)
+
+
+def preview_vegalite_json(vegalite_json):
+    return VegaLite(vegalite_json)
 
 
 def preview_vegalite(path):
@@ -375,15 +395,21 @@ def preview_audio(path: ty.Union[pathlib.Path, HttpUrl, ty.Callable], *args, **k
 
 
 ##############TODO: from here:###############################
-def preview_text(path: ty.Union[pathlib.Path, HttpUrl, ty.Callable]):
-    byts = getbytes(path)
+
+
+def preview_text_string(text_str):
     return Markdown(
         f"""
 ```
-{byts.decode()}
+{text_str}
 ```
 """
     )
+
+
+def preview_text(path: ty.Union[pathlib.Path, HttpUrl, ty.Callable]):
+    byts = getbytes(path)
+    return preview_text_string(byts.decode())
 
 
 def preview_dir(path: pathlib.Path):
@@ -403,6 +429,7 @@ def preview_text_or_dir(path):
         return preview_dir(path)
 
 
+# TODO: how to preview markdown not as a file, but as a string?
 def preview_markdown(path: pathlib.Path):
     import subprocess
 

--- a/src/ipyautoui/demo_schemas/ruleset.py
+++ b/src/ipyautoui/demo_schemas/ruleset.py
@@ -23,8 +23,7 @@ from enum import Enum
 from pydantic import BaseModel, Field
 from ipyautoui import AutoUi
 from ipyautoui.autoipywidget import AutoObject
-from random import choice, shuffle, randint
-from string import digits, ascii_lowercase
+from ipyautoui._utils import html_link
 
 URL_REVIT_FILTERS = "https://help.autodesk.com/view/RVT/2023/ENU/?guid=GUID-400FD74B-00E0-4573-B3AC-3965E65CBBDB"
 
@@ -34,14 +33,6 @@ URL_REVIT_FILTERS = "https://help.autodesk.com/view/RVT/2023/ENU/?guid=GUID-400F
 
 class StrEnum(str, Enum):
     pass
-
-
-def gen_word(N, min_N_digits, min_N_lower):
-    choose_from = [digits] * min_N_digits + [ascii_lowercase] * min_N_lower
-    choose_from.extend([digits + ascii_lowercase] * (N - min_N_lower - min_N_digits))
-    chars = [choice(bet) for bet in choose_from]
-    shuffle(chars)
-    return "".join(chars)
 
 
 def get_property_names():  # TODO: overwrite this
@@ -99,8 +90,6 @@ class RuleUi(AutoObject):  # RuleUi extends AutoObject allowing customisation
 
 
 # +
-def html_link(url, description, color="blue"):
-    return f'<font color="{color}"><a href="{url}" target="blank" >{description}</a></font>'
 
 
 class RuleSetType(str, Enum):
@@ -210,5 +199,3 @@ if __name__ == "__main__":
 
     aui = AutoUi(ScheduleRuleSet, show_raw=True, align_horizontal=False)
     display(aui)
-
-


### PR DESCRIPTION
create simple reusable functions for previewing strings: 
`preview_json_string`, `preview_yaml_string`, `preview_vega_json`, `preview_vegalite_json`, `preview_text_string`
this allows these functions to be used independently of the `getbytes` function which retrieves data from: path, request or callable