### PR TITLE
⬆️-use-maplocal-and-deprecate-mf_file_utilities

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,6 @@
 PYTHONPATH=${workspaceFolder}/src
+MAPLOCAL_OS_FROM="linux"
+MAPLOCAL_OS_TO="windows"
+MAPLOCAL_FROM=/home
+MAPLOCAL_TO=\\wsl.localhost\20221021\home
+MAPLOCAL_SCRIPT_PATH=maplocal_example.py

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": false
+        },
+        {
+            "name": "Python: Debug Tests",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": ["debug-test"],
+            "console": "integratedTerminal",
+            "justMyCode": false
+        }
+    ]
+}

--- a/docs/autodisplay.ipynb
+++ b/docs/autodisplay.ipynb
@@ -62,12 +62,13 @@
     "from ipyautoui import AutoUi, AutoDisplay\n",
     "from ipyautoui.constants import load_test_constants\n",
     "from IPython.display import display\n",
+    "import pathlib\n",
     "\n",
     "tests_constants = load_test_constants()\n",
     "DIR_FILETYPES = load_test_constants().DIR_FILETYPES\n",
     "paths = list(pathlib.Path(DIR_FILETYPES).glob(\"*.*\"))\n",
     "ad = AutoDisplay.from_paths(\n",
-    "    paths, newroot=pathlib.PureWindowsPath(\"C:/\"), display_showhide=False\n",
+    "    paths, display_showhide=False\n",
     ")\n",
     "display(ad)"
    ]
@@ -142,7 +143,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.15"
   },
   "vscode": {
    "interpreter": {

--- a/maplocal_example.py
+++ b/maplocal_example.py
@@ -1,0 +1,20 @@
+"""
+Environment:
+
+  - os = ubuntu
+  - wsl for windows
+  - running the the ubuntu file system
+"""
+
+import subprocess
+import pathlib
+
+
+def runcmd(cmd):
+    return subprocess.run(f"powershell.exe {cmd}", shell=True)
+
+
+def openpath(path):
+    if isinstance(path, pathlib.PurePath):
+        path = str(path)
+    return runcmd(f"explorer.exe '{path}'")

--- a/src/ipyautoui/_dev_sys_path_append.py
+++ b/src/ipyautoui/_dev_sys_path_append.py
@@ -2,7 +2,20 @@
 in the dev environment. It is called with a `%run _dev_sys_path_append.py`
 magic command so is not run when the module is imported.
 """
-import sys
+from dotenv import dotenv_values
 import pathlib
+import os
+import sys
 
-sys.path.append(str(pathlib.Path(__file__).parents[1]))
+rootdir = pathlib.Path(__file__).parents[2]
+config = dotenv_values(str(rootdir / ".env"))
+config["PYTHONPATH"] = str(rootdir / config["PYTHONPATH"].replace("/",""))
+config["MAPLOCAL_SCRIPT_PATH"] = str(rootdir / config["MAPLOCAL_SCRIPT_PATH"])
+
+for k, v in config.items():
+    if v is not None:
+        os.environ[k] = v
+
+sys.path.append(config["PYTHONPATH"])
+# ^ don't know why we have to do this as i think adding to 
+#   to PYTHONPATH should deal with this... but alas...

--- a/src/ipyautoui/_utils.py
+++ b/src/ipyautoui/_utils.py
@@ -15,20 +15,17 @@ import importlib.util
 import inspect
 import immutables
 import getpass
+import maplocal
 
 frozenmap = immutables.Map
 
+if maplocal.maplocal_openlocal_exists():
+    from maplocal import openlocal as open_path
+    from maplocal import maplocal as make_new_path
+else:
 
-def make_new_path(path, *args, **kwargs):
-    return path
-
-
-try:
-    # TODO: remove these.open_pathopen_path
-
-    from mf_file_utilities import go as open_path
-    from mf_file_utilities.applauncher_wrapper import make_new_path
-except:
+    def make_new_path(path, *args, **kwargs):
+        return path
 
     def open_path(path):
         import subprocess
@@ -223,7 +220,6 @@ def read_yaml(fpth, encoding="utf8"):
             return data
         except yaml.YAMLError as exc:
             print(exc)
-    
 
 
 def file(self: Type[BaseModel], path: pathlib.Path, **json_kwargs):

--- a/src/ipyautoui/_utils.py
+++ b/src/ipyautoui/_utils.py
@@ -24,12 +24,13 @@ def make_new_path(path, *args, **kwargs):
 
 
 try:
-    # TODO: remove these.
-    from mf_file_utilities import go as open_file
+    # TODO: remove these.open_pathopen_path
+
+    from mf_file_utilities import go as open_path
     from mf_file_utilities.applauncher_wrapper import make_new_path
 except:
 
-    def open_file(path):
+    def open_path(path):
         import subprocess
 
         subprocess.call(["open", path])

--- a/src/ipyautoui/_utils.py
+++ b/src/ipyautoui/_utils.py
@@ -219,9 +219,10 @@ def read_yaml(fpth, encoding="utf8"):
     with open(fpth, encoding=encoding) as stream:
         try:
             data = yaml.safe_load(stream)
+            return data
         except yaml.YAMLError as exc:
             print(exc)
-    return data
+    
 
 
 def file(self: Type[BaseModel], path: pathlib.Path, **json_kwargs):

--- a/src/ipyautoui/autodisplay.py
+++ b/src/ipyautoui/autodisplay.py
@@ -367,9 +367,7 @@ class DisplayObject(w.VBox):
         renderers = get_renderers(
             renderers=renderers, extend_default_renderers=extend_default_renderers
         )
-        display_actions = DisplayFromPath(
-            path=path, renderers=renderers
-        )
+        display_actions = DisplayFromPath(path=path, renderers=renderers)
         return cls(display_actions=display_actions, auto_open=auto_open)
 
     @classmethod
@@ -403,7 +401,7 @@ class DisplayObject(w.VBox):
         return cls(display_actions=display_actions, auto_open=auto_open)
 
     def tooltip_openpath(self, path):
-        return str(make_new_path(path)
+        return str(make_new_path(path))
 
     def _init_form(self):
         self.exists = w.Valid(
@@ -507,9 +505,7 @@ class DisplayPath(DisplayObject):
         self.renderers = get_renderers(
             renderers=renderers, extend_default_renderers=extend_default_renderers
         )
-        display_actions = DisplayFromPath(
-            path=value, renderers=self.renderers
-        )
+        display_actions = DisplayFromPath(path=value, renderers=self.renderers)
         super().__init__(display_actions=display_actions, **kwargs)
 
     @property
@@ -519,9 +515,7 @@ class DisplayPath(DisplayObject):
     @value.setter
     def value(self, value):
         self._value = ""
-        self.display_actions = DisplayFromPath(
-            path=value, renderers=self.renderers
-        )
+        self.display_actions = DisplayFromPath(path=value, renderers=self.renderers)
 
 
 # -
@@ -826,10 +820,7 @@ class AutoDisplay(tr.HasTraits):
         paths: ty.List[pathlib.Path],
         renderers=None,
     ):
-        return [
-            DisplayFromPath(path=path, renderers=renderers)
-            for path in paths
-        ]
+        return [DisplayFromPath(path=path, renderers=renderers) for path in paths]
 
     @staticmethod
     def actions_from_requests(map_requests: ty.Dict[str, HttpUrl], renderers=None):
@@ -857,9 +848,7 @@ class AutoDisplay(tr.HasTraits):
         else:
             renderers = DEFAULT_FILE_RENDERERS
         paths = [p for p in paths if p not in self.paths]
-        _new_actions = self.actions_from_paths(
-            paths=paths, renderers=renderers
-        )
+        _new_actions = self.actions_from_paths(paths=paths, renderers=renderers)
         actions = self.display_objects_actions + _new_actions
         self.display_objects_actions = actions
 
@@ -1000,9 +989,7 @@ if __name__ == "__main__":
     tests_constants = load_test_constants()
     DIR_FILETYPES = load_test_constants().DIR_FILETYPES
     paths = list(pathlib.Path(DIR_FILETYPES).glob("*"))
-    ad = AutoDisplay.from_paths(
-        paths, patterns="*.csv"
-    )
+    ad = AutoDisplay.from_paths(paths, patterns="*.csv")
     display(ad)
 # -
 if __name__ == "__main__":

--- a/src/ipyautoui/autodisplay.py
+++ b/src/ipyautoui/autodisplay.py
@@ -59,7 +59,7 @@ from ipyautoui.autodisplay_renderers import (
     handle_compound_ext,
 )
 from ipyautoui._utils import (
-    open_file,
+    open_path,
     make_new_path,
     frozenmap,
     get_ext,
@@ -189,7 +189,7 @@ class DisplayFromPath(DisplayObjectActions):
     def _open_file(cls, v, values):
         p = values["path"]
         if p is not None:
-            fn = functools.partial(open_file, p, newroot=values["newroot"])
+            fn = functools.partial(open_path, p, newroot=values["newroot"])
             return fn
         else:
             return lambda: "Error: path given is None"
@@ -200,7 +200,7 @@ class DisplayFromPath(DisplayObjectActions):
         if not p.is_dir():
             p = p.parent
         if p is not None:
-            fn = functools.partial(open_file, p, newroot=values["newroot"])
+            fn = functools.partial(open_path, p, newroot=values["newroot"])
             return fn
         else:
             return lambda: "Error: path given is None"
@@ -1077,5 +1077,3 @@ if __name__ == "__main__":
     test_display = AutoDisplay([d1, d2])
     display(Markdown("### From requests: "))
     display(test_display)
-
-

--- a/src/ipyautoui/autodisplay_renderers.py
+++ b/src/ipyautoui/autodisplay_renderers.py
@@ -20,7 +20,6 @@ The module lets us preview a data retrieved from: file, request or callable (< T
 """
 # %run _dev_sys_path_append.py
 # %run __init__.py
-#
 # %load_ext lab_black
 # +
 import os

--- a/src/ipyautoui/custom/_dev_sys_path_append.py
+++ b/src/ipyautoui/custom/_dev_sys_path_append.py
@@ -1,8 +1,0 @@
-"""this is only used when running the python files as jupyter notebooks
-in the dev environment. It is called with a ``
-magic command so is not run when the module is imported.
-"""
-import sys
-import pathlib
-
-sys.path.append(str(pathlib.Path(__file__).parents[2]))

--- a/src/ipyautoui/custom/autogrid.py
+++ b/src/ipyautoui/custom/autogrid.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.14.0
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -20,7 +20,7 @@
 contains methods for validation, coercion, and default values. 
 
 defines AutoGrid, a datagrid generated from a jsonschema."""
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 # %run ../__init__.py
 # %load_ext lab_black
@@ -1217,3 +1217,5 @@ if __name__ == "__main__":
 if __name__ == "__main__":
     grid.set_item_value(0, {"string": "check", "integer": 2, "floater": 3.0})
 # -
+
+

--- a/src/ipyautoui/custom/buttonbars.py
+++ b/src/ipyautoui/custom/buttonbars.py
@@ -14,7 +14,7 @@
 # ---
 
 # +
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 # %load_ext lab_black
 
@@ -31,6 +31,7 @@ from datetime import datetime
 from markdown import markdown
 import logging
 from enum import Enum
+
 logger = logging.getLogger(__name__)
 
 # +
@@ -421,5 +422,3 @@ if __name__ == "__main__":
     )
 
     display(buttonbar)
-
-

--- a/src/ipyautoui/custom/decision_branch.py
+++ b/src/ipyautoui/custom/decision_branch.py
@@ -20,7 +20,7 @@
 a UI element that loads a folder for data caching, whilst storing a record of folders in use
 """
 
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 #
 # %load_ext lab_black

--- a/src/ipyautoui/custom/editgrid.py
+++ b/src/ipyautoui/custom/editgrid.py
@@ -17,7 +17,7 @@
 
 # +
 """General widget for editing data"""
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 # %run ../__init__.py
 # %load_ext lab_black

--- a/src/ipyautoui/custom/filechooser.py
+++ b/src/ipyautoui/custom/filechooser.py
@@ -14,7 +14,7 @@
 # ---
 
 """wrapper for ipyfilechooster.FileChooser"""
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 # %load_ext lab_black
 

--- a/src/ipyautoui/custom/filesindir.py
+++ b/src/ipyautoui/custom/filesindir.py
@@ -14,7 +14,7 @@
 #     name: python3
 # ---
 
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 #
 # %load_ext lab_black

--- a/src/ipyautoui/custom/fileupload.py
+++ b/src/ipyautoui/custom/fileupload.py
@@ -17,7 +17,7 @@
 
 """file upload wrapper"""
 # %load_ext lab_black
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 # %run ../__init__.py
 
@@ -54,7 +54,8 @@ class File(BaseModel):
     @validator("path", always=True, pre=True)
     def _path(cls, v, values):
         return values["fdir"] / values["name"]
-    
+
+
 def read_file_upload_item(di: dict, fdir=pathlib.Path("."), added_by=None):
     if added_by is None:
         added_by = getuser()
@@ -65,6 +66,7 @@ def read_file_upload_item(di: dict, fdir=pathlib.Path("."), added_by=None):
     _["fdir"] = fdir
     _["added_by"] = added_by
     return File(**_)
+
 
 def add_file(upld_item, fdir=pathlib.Path(".")):
     f = read_file_upload_item(upld_item, fdir=fdir)
@@ -79,10 +81,12 @@ def add_files_ipywidgets8(upld_value, fdir=pathlib.Path(".")):
         di[l["name"]] = f
     return [v.path for v in di.values()]
 
+
 def add_files(upld_value, fdir=pathlib.Path(".")):
     if not pathlib.Path(fdir).exists():
         pathlib.Path(fdir).mkdir(exist_ok=True)
     return add_files_ipywidgets8(upld_value, fdir=fdir)
+
 
 class FilesUploadToDir(Array):
     def __init__(

--- a/src/ipyautoui/custom/iterable.py
+++ b/src/ipyautoui/custom/iterable.py
@@ -72,7 +72,7 @@ Example:
 """
 # TODO: move iterable.py to root
 # TODO: review: https://github.com/widgetti/reacton - it could simplify the code required below.
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 # %load_ext lab_black
 import ipywidgets as w

--- a/src/ipyautoui/custom/loadproject.py
+++ b/src/ipyautoui/custom/loadproject.py
@@ -14,7 +14,7 @@
 
 # %%
 """generic iterable object."""
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 #
 # %load_ext lab_black

--- a/src/ipyautoui/custom/markdown_widget.py
+++ b/src/ipyautoui/custom/markdown_widget.py
@@ -14,7 +14,7 @@
 # ---
 
 """simple markdown widget"""
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 #
 # %load_ext lab_black
@@ -233,5 +233,3 @@ if __name__ == "__main__":
         md: str = Field("adsf", format="markdown")
 
     display(AutoUi(Test))
-
-

--- a/src/ipyautoui/custom/outputlogging.py
+++ b/src/ipyautoui/custom/outputlogging.py
@@ -15,7 +15,7 @@
 
 # +
 """simple set-up of outputting logging messages to widgets output."""
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 #
 # %run ../__init__.py

--- a/src/ipyautoui/custom/selectdir.py
+++ b/src/ipyautoui/custom/selectdir.py
@@ -14,7 +14,7 @@
 # ---
 
 # +
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 #
 # %load_ext lab_black

--- a/src/ipyautoui/custom/showhide.py
+++ b/src/ipyautoui/custom/showhide.py
@@ -13,7 +13,7 @@
 #     name: python3
 # ---
 
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 #
 # %run ../__init__.py

--- a/src/ipyautoui/custom/title_description.py
+++ b/src/ipyautoui/custom/title_description.py
@@ -16,7 +16,7 @@
 # ---
 
 """generic support for observed title and description"""
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 # %run ../__init__.py
 # %load_ext lab_black

--- a/src/ipyautoui/custom/urlimagelink.py
+++ b/src/ipyautoui/custom/urlimagelink.py
@@ -14,9 +14,8 @@
 # ---
 
 # +
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
-#
 # %load_ext lab_black
 
 from IPython.display import display, HTML, clear_output

--- a/src/ipyautoui/custom/widgetcaller_error.py
+++ b/src/ipyautoui/custom/widgetcaller_error.py
@@ -19,7 +19,7 @@
 # %%
 """widget caller error"""
 # %load_ext lab_black
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 # %run ../__init__.py
 

--- a/src/ipyautoui/custom/workingdir.py
+++ b/src/ipyautoui/custom/workingdir.py
@@ -18,7 +18,7 @@
 a UI element that loads a folder for data caching, whilst storing a record of folders in use
 """
 
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 #
 # %load_ext lab_black
@@ -136,6 +136,7 @@ class WorkingDirs(BaseModel):
 
 
 # + tags=[]
+
 
 def get_working_dirs(path=FPTH_WORKING_DIRS):
     """loads working dir from folder"""

--- a/src/ipyautoui/demo_schemas/_dev_sys_path_append.py
+++ b/src/ipyautoui/demo_schemas/_dev_sys_path_append.py
@@ -1,8 +1,0 @@
-"""this is only used when running the python files as jupyter notebooks
-in the dev environment. It is called with a ``
-magic command so is not run when the module is imported.
-"""
-import sys
-import pathlib
-
-sys.path.append(str(pathlib.Path(__file__).parents[2]))

--- a/src/ipyautoui/demo_schemas/ruleset.py
+++ b/src/ipyautoui/demo_schemas/ruleset.py
@@ -15,7 +15,7 @@
 # ---
 
 # %%
-# %run _dev_sys_path_append.py
+# %run ../_dev_sys_path_append.py
 # %run __init__.py
 # %run ../__init__.py
 # %load_ext lab_black

--- a/tests/test_maplocal_openfile.py
+++ b/tests/test_maplocal_openfile.py
@@ -1,0 +1,26 @@
+import pathlib
+import typing as ty
+
+# NOTE: this requires user specific configuration of the .env file to work
+from maplocal import maplocal, openlocal
+from maplocal.maplocal import MAPENV
+
+
+class TestMAPENV:
+    def test_MAPENV(self):
+        assert MAPENV.MAPLOCAL_FROM == pathlib.PurePosixPath("/home")
+        assert MAPENV.MAPLOCAL_TO == pathlib.PureWindowsPath(
+            "//wsl.localhost/20221021/home"
+        )
+
+
+class TestEnv:
+    # @pytest.mark.usefixtures("mock_env_user")
+    def test_dev_env(self):
+
+        assert isinstance(MAPENV.openpath, ty.Callable)
+        p = pathlib.Path(__file__).resolve()
+        assert maplocal(p) == pathlib.PureWindowsPath(
+            "//wsl.localhost/20221021/home/jovyan/ipyautoui/tests/test_maplocal_openfile.py"
+        )
+        openlocal(p)


### PR DESCRIPTION
deprecated `mf_file_utilities`. 
uses `maplocal` to map files on a shared drive from a server App to the users local machine. 
see `maplocal-mxf` repo (private) for an example of how to use it on an on-prem server using repo2docker.
see example  `test_maplocal_openfile.py` for an example of using it to map wsl to windows c drive