### PR TITLE
Fix indentation of open_path

### DIFF
--- a/src/ipyautoui/_utils.py
+++ b/src/ipyautoui/_utils.py
@@ -43,14 +43,14 @@ except:
     def make_new_path(path, *args, **kwargs):
         return path
 
-        def open_path(path):
-            import subprocess
-            import sys
+    def open_path(path):
+        import subprocess
+        import sys
 
-            if sys.platform == "linux":
-                subprocess.call(["xdg-open", path])
-            else:
-                subprocess.call(["explorer.exe", path])
+        if sys.platform == "linux":
+            subprocess.call(["xdg-open", path])
+        else:
+            subprocess.call(["explorer.exe", path])
 
 
 def getuser():


### PR DESCRIPTION
The indent level was incorrect in one of the code branches, making it impossible to import under ipyautoui under some circumstances.

PS Thanks for the excellent package!