### PR TITLE
♻️ Don't set default when trying to set empty list

### DIFF
--- a/src/ipyautoui/custom/autogrid.py
+++ b/src/ipyautoui/custom/autogrid.py
@@ -765,9 +765,12 @@ class AutoGrid(DataGrid):
         return self.column_names[index]
 
     def get_default_data(self):
-        data = pd.DataFrame(self.gridschema._get_default_data(), columns=self.map_index_name)
-        if self.by_title:
-            data = data.rename(columns=self.map_name_index)
+        if self.gridschema._get_default_data():
+            data = pd.DataFrame(self.gridschema._get_default_data())
+            if self.by_title:
+                data = data.rename(columns=self.map_name_index)
+        else:
+            data = pd.DataFrame(self.gridschema._get_default_data(), columns=self.map_index_name)
         return data
 
     def _init_data(self, data) -> pd.DataFrame:

--- a/src/ipyautoui/custom/editgrid.py
+++ b/src/ipyautoui/custom/editgrid.py
@@ -262,10 +262,7 @@ class EditGrid(w.VBox, TitleDescription):
 
     @value.setter
     def value(self, value):
-        if not value:
-            self.grid.data = self.grid.get_default_data()
-        else:
-            self.grid.data = self.grid._init_data(pd.DataFrame(value))
+        self.grid.data = self.grid._init_data(pd.DataFrame(value))
 
         # HOTFIX: Setting data creates bugs out transforms currently so reset transform applied
         _transforms = self.grid._transforms
@@ -743,11 +740,12 @@ if __name__ == "__main__":
         ui_add=None,
         ui_edit=None,
         warn_on_delete=True,
+        by_title=False,
     )
     editgrid.observe(lambda c: print("_value changed"), "_value")
     display(editgrid)
 
 if __name__ == "__main__":
-    editgrid.transposed = True
+    editgrid.transposed = False
 
 


### PR DESCRIPTION
When settings an empty list (or tuple) to an EditGrid object, set an empty dataframe to EditGrid.grid.data. Before these changes, it was setting a default value when trying to set to an empty list which meant that there could never be an empty EditGrid.