### PR TITLE
🐛 Clear output after file download triggered

### DIFF
--- a/src/ipyautoui/custom/filedownload.py
+++ b/src/ipyautoui/custom/filedownload.py
@@ -62,6 +62,7 @@ def trigger_download(content_b64: str, fname: str, output, kind: str = "text/jso
         print("---")
         clear_output()
         display(HTML(f"<script>{js_code}</script>"))
+        clear_output()
 
 
 class _Base(w.VBox):

--- a/src/ipyautoui/custom/svgspinner.py
+++ b/src/ipyautoui/custom/svgspinner.py
@@ -38,7 +38,7 @@ class SvgSpinner(w.VBox):
     def __init__(self, path_svg=PATH_SVG):
         super().__init__()
         self.path_svg = path_svg
-        self.out = w.Output()
+        self.out = w.Output(layout=dict(width="25px"))
         self.children = [self.out]
         self.display_spinner()
 


### PR DESCRIPTION
🐛 Set output widget for SVG spinner to fixed width