### PR TITLE
297-filter_pattern-in-a-field-does-not-get-sent-to-filechooser

### DIFF
--- a/src/ipyautoui/custom/iterable.py
+++ b/src/ipyautoui/custom/iterable.py
@@ -45,7 +45,6 @@ from ipyautoui.custom.title_description import TitleDescription
 import enum
 import string
 import random
-import inspect
 from ipyautoui.automapschema import from_schema_method, get_widget
 from jsonref import replace_refs
 from ipyautoui.watch_validate import WatchValidate

--- a/tests/custom/test_filechooser.py
+++ b/tests/custom/test_filechooser.py
@@ -1,0 +1,18 @@
+
+from pydantic import BaseModel, Field
+from ipyautoui import AutoUi
+from ipyautoui.custom.filechooser import FileChooser
+import pathlib
+
+def test_filechooser():
+    class Test(BaseModel):
+        path: pathlib.Path = Field(
+            ".", json_schema_extra=dict(filter_pattern=["*_.py"])
+        )  # note. filter_pattern ipyfilechooser kwarg passed on
+        string: str = "test"
+
+    ui = AutoUi(Test)
+    
+    assert isinstance(ui.di_widgets["path"], FileChooser)
+    assert ui.di_widgets["path"].value == "."
+    assert ui.di_widgets["path"].filter_pattern == ["*_.py"]


### PR DESCRIPTION
adds all the keyword arguments from the orginal filechooser __init__ to ensure that they are present in the argspec