### PR TITLE
🐛 Fix display issue of nested widgets with nullable

### DIFF
--- a/src/ipyautoui/autoobject.py
+++ b/src/ipyautoui/autoobject.py
@@ -121,7 +121,7 @@ class AutoObject(w.VBox, WatchValidate, TitleDescription):
     def _show_null(self, yesno: bool):
         for k, v in self.di_boxes.items():
             if k in self.value.keys():
-                if pd.isnull(self.value[k]):
+                if self.value[k] is None:
                     v.layout.display = (lambda yesno: "" if yesno else "None")(yesno)
                 else:
                     v.layout.display = ""

--- a/src/ipyautoui/autoobject.py
+++ b/src/ipyautoui/autoobject.py
@@ -121,11 +121,10 @@ class AutoObject(w.VBox, WatchValidate, TitleDescription):
     def _show_null(self, yesno: bool):
         for k, v in self.di_boxes.items():
             if k in self.value.keys():
-                if not isinstance(self.value[k], (dict, list)):
-                    if pd.isnull(self.value[k]):
-                        v.layout.display = (lambda yesno: "" if yesno else "None")(yesno)
-                    else:
-                        v.layout.display = ""
+                if pd.isnull(self.value[k]):
+                    v.layout.display = (lambda yesno: "" if yesno else "None")(yesno)
+                else:
+                    v.layout.display = ""
             else:
                 # If no value passed assume value is None
                 v.layout.display = (lambda yesno: "" if yesno else "None")(yesno)


### PR DESCRIPTION
Setting the value of an AutoObject that contains a nullable NestedObject now appears if the value set is not None. If it is None the widget is hidden as expected.

The reason this wasn't working was because there was an if statement that was checking whether the value passed is a list or dict. There was no "else" statement to deal with this. From a review, it looks like this "if" statement doesn't need to exist at all so it has been removed.