### PR TITLE
🐛 Fix indenting of widgets in AutoObject

### DIFF
--- a/src/ipyautoui/autobox.py
+++ b/src/ipyautoui/autobox.py
@@ -40,7 +40,7 @@ f1 = lambda self: [
             self.hbx_title_description,
         ]
     ),
-    self.widget,
+    w.HBox([SPACER, self.widget]),
 ]
 f2 = lambda self: [
     w.HBox(

--- a/src/ipyautoui/autoobject.py
+++ b/src/ipyautoui/autoobject.py
@@ -379,14 +379,19 @@ class AutoObject(w.VBox, WatchValidate, TitleDescription):
             for k in self.di_callers.keys()
         }
         self.vbx_widget.children = list(self.di_boxes.values())
-        self.indent_non_nullable()
+        self.indent_widgets()
 
-    def indent_non_nullable(self):
+    def indent_widgets(self):
+        """Indent the widgets appropriately based on the schema.
+        Any widget that is not nullable and has a type of "array" will be indented."""
         li = [v.allow_none for v in self.di_callers.values()]
         if True in li:
             for k, v in self.di_callers.items():
                 if not v.allow_none:
                     self.di_boxes[k].indent = True
+                if "type" in v.kwargs and v.kwargs["type"] == "array":
+                    self.di_boxes[k].indent = True
+
 
     def _insert_rows(self):
         if self.insert_rows is not None:

--- a/src/ipyautoui/nullable.py
+++ b/src/ipyautoui/nullable.py
@@ -1,8 +1,10 @@
 import functools
+import pandas as pd
 import ipywidgets as w
 import traitlets as tr
+
 from ipyautoui.constants import BUTTON_WIDTH_MIN
-import pandas as pd
+
 SHOW_NONE_KWARGS = dict(value="None", disabled=True, layout={"display": "None"})
 
 


### PR DESCRIPTION
Updated formatting so that a spacer is added to widgets of type array.
Ensured that indent is set to true for widgets of type array.