### PR TITLE
♻️ Create is_null function and implement where pd.isnull is used

### DIFF
--- a/src/ipyautoui/_utils.py
+++ b/src/ipyautoui/_utils.py
@@ -1,24 +1,25 @@
+import io
 import os
-import pathlib
 import json
 import yaml
-import importlib
-from typing import Type
-from markdown import markdown
-from math import log10, floor
-import ipywidgets as w
-from IPython.display import display, Markdown
 import codecs
-from pydantic import BaseModel, field_validator, Field, ValidationInfo
-import typing as ty
-import importlib.util
+import zipfile
+import logging
+import pathlib
+import getpass
 import inspect
 import immutables
-import getpass
-import logging
-import io
-import zipfile
+import importlib
+import importlib.util
+import pandas as pd
+import ipywidgets as w
+import typing as ty
+from typing import Type
 from base64 import b64encode
+from markdown import markdown
+from math import log10, floor
+from pydantic import BaseModel, field_validator, Field, ValidationInfo
+from IPython.display import display, Markdown
 
 logger = logging.getLogger(__name__)
 frozenmap = immutables.Map
@@ -502,3 +503,16 @@ def calc_select_multiple_size(no_items, min=100, max=600, step=5.8):
         return max
     else:
         return h
+    
+def is_null(v) -> bool:
+    """Check if a value is null.
+
+    This function exists because pd.isnull returns an ndarray of bools for
+    non-scalar values, which is not what we want. Therefore, we check if the
+    value is a list, dict, pd.Series, or pd.DataFrame and return False if it is,
+    otherwise we return the result of pd.isnull.
+    """
+    if isinstance(v, (list, dict, pd.Series, pd.DataFrame)):
+        return False
+    else:
+        return pd.isnull(v)

--- a/src/ipyautoui/autoobject.py
+++ b/src/ipyautoui/autoobject.py
@@ -22,12 +22,12 @@
 import logging
 import pathlib
 import ipywidgets as w
-import pandas as pd  # TODO: pandas is a heavy dep. if only used for pd.isnull... ? 
 import traitlets as tr
 from IPython.display import display
 from jsonref import replace_refs
+
 import ipyautoui.automapschema as aumap
-from ipyautoui._utils import obj_from_importstr
+from ipyautoui._utils import obj_from_importstr, is_null
 from ipyautoui.nullable import Nullable
 from ipyautoui.autobox import AutoBox
 from ipyautoui.autoform import AutoObjectFormLayout
@@ -121,7 +121,7 @@ class AutoObject(w.VBox, WatchValidate):
     def _show_null(self, yesno: bool):
         for k, v in self.di_boxes.items():
             if k in self.value.keys():
-                if self.value[k] is None:
+                if is_null(self.value[k]):
                     v.layout.display = (lambda yesno: "" if yesno else "None")(yesno)
                 else:
                     v.layout.display = ""
@@ -418,7 +418,7 @@ class AutoObject(w.VBox, WatchValidate):
         with self.silence_autoui_traits():
             for k, v in self.value.items():
                 if k in self.di_widgets.keys():
-                    if v is None and not isinstance(self.di_widgets[k], Nullable):
+                    if is_null(v) and not isinstance(self.di_widgets[k], Nullable):
                         v = _get_value_trait(self.di_widgets[k]).default()
                     try:
                         self.di_widgets[k].value = v

--- a/src/ipyautoui/nullable.py
+++ b/src/ipyautoui/nullable.py
@@ -1,9 +1,9 @@
 import functools
-import pandas as pd
 import ipywidgets as w
 import traitlets as tr
 
 from ipyautoui.constants import BUTTON_WIDTH_MIN
+from ipyautoui._utils import is_null
 
 SHOW_NONE_KWARGS = dict(value="None", disabled=True, layout={"display": "None"})
 
@@ -89,9 +89,7 @@ class Nullable(w.HBox):
 
     @value.setter
     def value(self, value):
-        if isinstance(value, dict) or isinstance(value, list):
-            self.update_value(value)
-        elif pd.isnull(value):
+        if is_null(value):
             self.bn.value = True
             self._value = None
         else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+import pandas as pd
+import numpy as np
+from ipyautoui._utils import is_null
+
+def test_is_null():
+    assert is_null(None) == True
+    assert is_null(np.nan) == True
+    assert is_null(0) == False
+    assert is_null("None") == False
+    assert is_null("NULL") == False
+    assert is_null([1, 2]) == False
+    assert is_null({"a": 1, "b": 2}) == False
+    assert is_null(pd.Series([1, 2])) == False
+    assert is_null(pd.DataFrame({"a": [1, 2]})) == False


### PR DESCRIPTION
Implementing use of `pd.isnull` where applicable.

Before we were just checking for `None`, however, pandas data frame returns `nan` and therefore was not being captured by the if statement correctly. 

The issue was caused by this [commit](https://github.com/maxfordham/ipyautoui/commit/e986b9a4ca287f82e733502b10faa07aa9bbc198) and will be reverted in this PR.

To finally resolve this issue, an `is_null` function has been created and used in place of `pd.isnull`.