### PR TITLE
👷‍♂️ Fix deploy book workflow

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - nbsphinx-link
   - sphinxcontrib-mermaid
   - sphinx-panels
+  - nbclient>=0.7.4
   - pip
   - pip:
     - maplocal==0.2.1


### PR DESCRIPTION
Fixed by pinning `nbclient>=0.7.4`