### PR TITLE
Fix bugs in setting FileChooser value

### DIFF
--- a/src/ipyautoui/custom/filechooser.py
+++ b/src/ipyautoui/custom/filechooser.py
@@ -62,11 +62,11 @@ class FileChooser(FileChooser):
         self._value = str(value)
         p = pathlib.Path(self.value)
         if p.is_dir():
-            self.reset(self.value, None)
+            self.reset(self.value, "")
         elif p.is_file():
             self.reset(p.parent, p.name)
         elif p.parent.is_dir():
-            self.reset(p.parent, None)
+            self.reset(p.parent, p.name)
         else:
             raise ValueError(f"{str(p)} not a valid path or dir")
         self._apply_selection()

--- a/tests/custom/test_filechooser.py
+++ b/tests/custom/test_filechooser.py
@@ -16,3 +16,20 @@ def test_filechooser():
     assert isinstance(ui.di_widgets["path"], FileChooser)
     assert ui.di_widgets["path"].value == "."
     assert ui.di_widgets["path"].filter_pattern == ["*_.py"]
+
+
+def test_filechooser_set_value(tmp_path):
+    # Make sure that setting a filename which does not exist works,
+    # i.e. the filename is retained and the path is set to the parent directory.
+    fc = FileChooser()
+    fc.value = tmp_path / "does_not_exist.txt"
+    assert fc.selected_filename == "does_not_exist.txt"
+    assert fc.selected_path == str(tmp_path)
+
+    # Try changing the value to a directory that exists.
+    new_path = tmp_path / "new_directory"
+    new_path.mkdir()
+    fc.value = new_path
+    assert fc.selected_filename == ""
+    # Use samefile below so there is no need to worry about trailing slashes.
+    assert (tmp_path / "new_directory").samefile(fc.selected_path)


### PR DESCRIPTION
This pull requests fixes a couple of issues with. setting the value of a `FileChooser` widget. 

There were two separate issues, though they had similar fixes.

The first issue was that setting the value to a file that did not exist was impossible. This code demonstrates that bug:

```python
import tempfile
from pathlib import Path

from ipyautoui.custom.filechooser import FileChooser

fc = FileChooser()

with tempfile.TemporaryDirectory() as tmpdirname:
    tmp_path = Path(tmpdirname)
    fc.value = tmp_path / "does_not_exist.txt"
    assert fc.selected_filename == "does_not_exist.txt"  # Fails because fc.selected_filename is ""
```

The root cause in this case is [this line](https://github.com/maxfordham/ipyautoui/blob/main/src/ipyautoui/custom/filechooser.py#L68), where I think the correct behavior is to set both the path and name.

The second issue is that setting the `FileChooser` value to an existing directory after having set the `FileChooser` file that exists fails to update the `selected_filename`, as demonstrated by this code:

```python
import tempfile
from pathlib import Path

from ipyautoui.custom.filechooser import FileChooser

fc = FileChooser()

with tempfile.TemporaryDirectory() as tmpdirname:
    tmp_path = Path(tmpdirname)
    new_file = tmp_path / "does_not_exist.txt"
    new_file.touch()
    fc.value = new_file
    assert fc.selected_filename == "does_not_exist.txt"  # Work since the file exists

    new_dir_path = tmp_path / "new_directory/"
    new_dir_path.mkdir()
    fc.value = new_dir_path
    assert fc.selected_filename == ""  # Fails because fc.selected_filename is still "does_not_exist.txt"
```

The root cause of this issue is the handling of [this case](https://github.com/maxfordham/ipyautoui/blob/main/src/ipyautoui/custom/filechooser.py#L65), where `""` should be passed as the file name instead of `None` to indicate there is no file.


