### PR TITLE
🐛 Check for private traits with similar naming in `kwargs`

### DIFF
--- a/src/ipyautoui/_utils.py
+++ b/src/ipyautoui/_utils.py
@@ -369,7 +369,8 @@ def traits_in_kwargs(call: ty.Callable, kwargs: dict):
         logger.info(f"{call.__name__} does not have traits attribute")
         return {}
     else:
-        return {k: v for k, v in kwargs.items() if k in list(call.traits(call).keys())}
+        li = list(call.traits(call).keys())
+        return {k: v for k, v in kwargs.items() if k in li or f"_{k}" in li}
 
 
 def remove_non_present_kwargs(callable_: ty.Callable, di: dict):

--- a/src/ipyautoui/demo_schemas/override_ipywidgets.py
+++ b/src/ipyautoui/demo_schemas/override_ipywidgets.py
@@ -12,6 +12,13 @@ class OverrideIpywidgets(BaseModel):
         default="asd",
         json_schema_extra=dict(enum=["asd", "asdf"], autoui="ipywidgets.Combobox"),
     )
+    combobox_mapped: str = Field(
+        default="asd",
+        json_schema_extra=dict(
+            options={"ASD": "asd", "ASDF": "asdf"},
+            autoui="ipyautoui.custom.combobox_mapped.ComboboxMapped",
+        ),
+    )
     toggle: bool = Field(
         default=True,
         title="Toggle Button",

--- a/tests/test_automapschema.py
+++ b/tests/test_automapschema.py
@@ -92,6 +92,27 @@ def test_combobox():
     assert_widget_map(schema)
 
 
+def test_combobox_mapped():
+    class Test(BaseModel):
+        """Test to see that widgets with private traits are captured by kwargs when mapping to the widget.
+        E.g. ComboboxMapped has the traits `_value` and `_options` which should be captured by kwargs.
+        """
+
+        combobox_mapped: str = Field(
+            "apple",
+            json_schema_extra=dict(
+                options={"APPLE": "apple", "PEAR": "pear"},
+                autoui="ipyautoui.custom.combobox_mapped.ComboboxMapped",
+            ),
+        )
+
+    model, schema = _init_model_schema(Test)
+    assert_widget_map(schema)
+    widget_caller = map_widget(schema["properties"]["combobox_mapped"])
+    assert widget_caller.kwargs["value"] == "apple"
+    assert widget_caller.kwargs["options"] == {"APPLE": "apple", "PEAR": "pear"}
+
+
 def test_CoreIpywidgets():
     assert_widget_map(CoreIpywidgets)
 


### PR DESCRIPTION
For example, the function `traits_in_kwargs` now checks for `_value` in the function if `value` is present in `kwargs`.