### PR TITLE
🐛 Only set html_unit value if unit defined

### DIFF
--- a/src/ipyautoui/custom/title_description.py
+++ b/src/ipyautoui/custom/title_description.py
@@ -40,7 +40,10 @@ class TitleDescription(tr.HasTraits):
 
     @tr.observe("unit")
     def _observe_unit(self, change):
-        self.html_unit.value += f"<b>({self.unit})</b>"
+        if self.unit:
+            self.html_unit.value += f"<b>({self.unit})</b>"
+        else:
+            self.html_unit.value = ""
 
     @tr.observe("description")
     def _observe_description(self, change):


### PR DESCRIPTION
Resolves the issue where empty parentheses were being shown.