### PR TITLE
✨ GridSchema: if value missing, use default value from schema

### DIFF
--- a/docs/issue-17.ipynb
+++ b/docs/issue-17.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "104f405e-c72a-4c6d-a808-32fb3a3307f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import typing as ty\n",
+    "import pandas as pd\n",
+    "from pydantic import BaseModel, RootModel, Field\n",
+    "\n",
+    "import ipyautoui.automapschema as asch\n",
+    "from ipyautoui import AutoUi\n",
+    "from ipyautoui.custom.autogrid import AutoGrid, GridSchema\n",
+    "from ipyautoui.custom.editgrid import EditGrid\n",
+    "from ipyautoui.custom.iterable import AutoArray\n",
+    "from ipyautoui.autoobject import AutoObject"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "9e63844a-a11f-4fe9-b0be-8dd34e5df933",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "96d8fa3c98fb4565a12220cb3de41a95",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AutoArray(children=(VBox(children=(Button(button_style='success', icon='plus', layout=Layout(display='', width…"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class TestListCol(BaseModel):\n",
+    "    li_col: list[str] = [\"a\"]\n",
+    "    stringy: str = \"as\"\n",
+    "    num: int = 1\n",
+    "\n",
+    "class Test(RootModel):\n",
+    "    root: list[TestListCol] = [TestListCol(li_col=[\"a\", \"b\"], stringy=\"asdfsadf\", num=3)]\n",
+    "\n",
+    "AutoArray.from_jsonschema(Test.model_json_schema())  # Defaults not being added"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "f3557480-0510-4a0c-a62c-b448f2b1bc87",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3bed93561f30489f8f14b54ff6368085",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AutoObject(children=(VBox(children=(AutoBox(children=(HBox(children=(ToggleButton(value=False, description='sh…"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class TestListCol(BaseModel):\n",
+    "    li_col: list[str] = [\"a\"]\n",
+    "    stringy: str = \"as\"\n",
+    "    num: int = 1\n",
+    "\n",
+    "class Test(BaseModel):\n",
+    "    li_test_list: list[TestListCol] = [TestListCol(li_col=[\"a\", \"b\"], stringy=\"asdfsadf\", num=3)]\n",
+    "\n",
+    "AutoObject.from_jsonschema(Test.model_json_schema())  # Defaults not being added"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "2bbaa6e7-d8cb-4e5c-b8c9-ef80f5c1b167",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TestListCol(BaseModel):\n",
+    "    li_col: list[str] = [\"a\"]\n",
+    "    stringy: str = \"as\"\n",
+    "    num: int = 1\n",
+    "\n",
+    "class Test(RootModel):\n",
+    "    root: list[TestListCol] = Field([TestListCol(li_col=[\"a\", \"b\"], stringy=\"asdfsadf\", num=3)], format=\"dataframe\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "1c08888d-60f2-4e75-ba83-e98bc1d983a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5f0b94474f0b46fb9b774c8018af007e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "EditGrid(children=(HBox(children=(HTML(value=''), HTML(value=''), HTML(value=''))), VBox(children=(CrudButtonB…"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "EditGrid(schema=Test)  # Currently works for dataframe format (with EditGrid). Default row is added from Test RootModel, and AutoObjectForm shows defaults from TestListCol "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aae53446-3b45-4b17-919a-5da9e2b0ea90",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/issue-332.ipynb
+++ b/docs/issue-332.ipynb
@@ -12,12 +12,15 @@
     "from pydantic import BaseModel, RootModel, Field\n",
     "\n",
     "import ipyautoui.automapschema as asch\n",
-    "from ipyautoui.custom.autogrid import AutoGrid, GridSchema"
+    "from ipyautoui.custom.autogrid import AutoGrid, GridSchema\n",
+    "from ipyautoui.custom.editgrid import EditGrid\n",
+    "from ipyautoui.custom.iterable import AutoArrayForm\n",
+    "from ipyautoui.autoobject import AutoObject"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 2,
    "id": "f8b9a2cb-69be-4c93-ae67-be336f115e26",
    "metadata": {},
    "outputs": [],
@@ -33,15 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "24eb0820-8902-4f74-a049-7d995f14e081",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 30,
    "id": "7f09f74a-8a45-4f46-8168-0fa98b8e438e",
    "metadata": {},
    "outputs": [
@@ -85,7 +80,7 @@
        "0                2"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -95,6 +90,14 @@
     "gridschema = GridSchema(schema)\n",
     "gridschema.coerce_data(pd.DataFrame([{\"number\": 2}]))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4a48ae0-5949-49e0-840c-15bd7e7bad55",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/issue-332.ipynb
+++ b/docs/issue-332.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "85eaed4e-12b4-4fec-8cd0-a183f356bf2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import typing as ty\n",
+    "import pandas as pd\n",
+    "from pydantic import BaseModel, RootModel, Field\n",
+    "\n",
+    "import ipyautoui.automapschema as asch\n",
+    "from ipyautoui.custom.autogrid import AutoGrid, GridSchema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "f8b9a2cb-69be-4c93-ae67-be336f115e26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Test(BaseModel):\n",
+    "    text: str = \"\"\n",
+    "    number: float\n",
+    "\n",
+    "\n",
+    "class TestDataFrame(RootModel):\n",
+    "    root: ty.List[Test] = Field(format=\"dataframe\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24eb0820-8902-4f74-a049-7d995f14e081",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "7f09f74a-8a45-4f46-8168-0fa98b8e438e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>title</th>\n",
+       "      <th>Text</th>\n",
+       "      <th>Number</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td></td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "title Text  Number\n",
+       "0                2"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model, schema = asch._init_model_schema(TestDataFrame)\n",
+    "gridschema = GridSchema(schema)\n",
+    "gridschema.coerce_data(pd.DataFrame([{\"number\": 2}]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/ipyautoui/autoform.py
+++ b/src/ipyautoui/autoform.py
@@ -54,8 +54,13 @@ class ShowNull(tr.HasTraits):
 
     def show_hide_bn_nullable(self):
         """Set display of show null button based on if any nullable widgets are found."""
-        if self.check_for_nullables():  # check_for_nullables is defined in AutoObject
-            self.display_bn_shownull = True
+        if hasattr(self, "check_for_nullables"):
+            if (
+                self.check_for_nullables()
+            ):  # check_for_nullables is defined in AutoObject
+                self.display_bn_shownull = True
+            else:
+                self.display_bn_shownull = False
         else:
             self.display_bn_shownull = False
 

--- a/src/ipyautoui/automapschema.py
+++ b/src/ipyautoui/automapschema.py
@@ -54,46 +54,6 @@ def pydantic_validate(model, value):
     return model.model_validate(value).model_dump(mode="json")
 
 
-# def is_Nullable(di: dict) -> bool:
-#     """
-#     is_Nullable({'title': 'floater', 'default': 1.33, 'anyOf': [{'type': 'string'}, {'type': 'null'}]})
-#     True
-#     """
-#     if "type" not in di.keys() and "anyOf" in di.keys():
-#         if "null" in [l.get("type") for l in di["anyOf"]]:
-#             return True
-#         else:
-#             return False
-#     else:
-#         return False
-
-
-# def get_type(di: dict) -> str:
-#     if "type" in di.keys():
-#         return di["type"]
-#     else:
-#         if "anyOf" in di.keys():
-#             kw = "anyOf"
-#         elif "allOf" in di.keys():
-#             kw = "allOf"
-#         else:
-#             raise ValueError("currently must have anyOf or allOf or type in schema")
-#         types = list(set([l.get("type") for l in di[kw]]))
-#         if len(types) > 2:
-#             raise ValueError(
-#                 f"currently a single type must be specified. a specific type + null is also allowed. not {str([l['type'] for l in di['anyOf']])}"
-#             )
-#         else:
-#             t = [l for l in types if l != "null"][0]
-#             return t
-
-
-# def get_type_and_nullable(di: dict) -> tuple[str, bool]:
-#     type_ = get_type(di)
-#     nullable = is_Nullable(di)
-#     return type_, nullable
-
-
 def is_allowed_type(di: dict) -> bool:
     #  https://json-schema.org/understanding-json-schema/reference/combining.html
     if "anyOf" in di:

--- a/src/ipyautoui/custom/autogrid.py
+++ b/src/ipyautoui/custom/autogrid.py
@@ -425,7 +425,13 @@ class GridSchema:
             if default_value is None:
                 return col
             else:
-                return col.apply(lambda x: default_value if pd.isna(x) else x)
+                return col.apply(
+                    lambda x: (
+                        default_value
+                        if (pd.isna(x).all() if isinstance(x, list) else pd.isna(x))
+                        else x
+                    )
+                )
 
         if order is None:
             order = self.default_order

--- a/src/ipyautoui/custom/autogrid.py
+++ b/src/ipyautoui/custom/autogrid.py
@@ -420,6 +420,12 @@ class GridSchema:
                 drop = [l for l in col_names if l not in self.get_order_titles(order)]
             return data.drop(drop, axis=1)
 
+        def fill_with_default(col):
+            default_value = self._get_default_row().get(col.name)
+            if default_value is not None:
+                return col.fillna(default_value)
+            return col
+
         if order is None:
             order = self.default_order
 
@@ -432,10 +438,9 @@ class GridSchema:
 
         if len(col_names) < len(order):
             # add missing columns
-            data = data.reindex(
-                columns=order,
-                # fill_value=self._get_default_row(),  # TODO: check this.
-            )
+            data = data.reindex(columns=order)
+
+        data = data.apply(fill_with_default)
 
         # map column names to outward facing names
         if bykeys:

--- a/src/ipyautoui/custom/autogrid.py
+++ b/src/ipyautoui/custom/autogrid.py
@@ -422,9 +422,10 @@ class GridSchema:
 
         def fill_with_default(col):
             default_value = self._get_default_row().get(col.name)
-            if default_value is not None:
-                return col.fillna(default_value)
-            return col
+            if default_value is None:
+                return col
+            else:
+                return col.apply(lambda x: default_value if pd.isna(x) else x)
 
         if order is None:
             order = self.default_order

--- a/tests/test_autogrid.py
+++ b/tests/test_autogrid.py
@@ -1,7 +1,8 @@
 import pytest
 import pandas as pd
-from pydantic import BaseModel, Field, RootModel
 import typing as ty
+from datetime import datetime
+from pydantic import BaseModel, Field, RootModel
 
 from ipyautoui.custom.autogrid import AutoGrid, GridSchema
 from ipyautoui.automapschema import _init_model_schema
@@ -11,12 +12,6 @@ from .constants import DIR_TESTS
 
 DIR_TEST_DATA = DIR_TESTS / "test_data"
 DIR_TEST_DATA.mkdir(parents=True, exist_ok=True)
-
-
-# def test_get_visible_data():
-#     agr = AutoGrid(schema=EditableGrid, data = pd.DataFrame(DATAGRID_TEST_VALUE*2))
-
-#     print("done")
 
 
 class TestGridSchema:
@@ -314,6 +309,12 @@ class TestGridSchema:
         class Test(BaseModel):
             text: str = ""
             number: float
+            integer: int = 1
+            boolean: bool = True
+            optional_string: ty.Optional[str] = None
+            date_time: datetime = datetime(2020, 1, 1)
+            dictionary: dict = {"test": "test"}
+            array: list = ["test", "test again"]
 
         class TestDataFrame(RootModel):
             root: ty.List[Test] = Field(format="dataframe")
@@ -322,6 +323,15 @@ class TestGridSchema:
         gridschema = GridSchema(schema)
         data = gridschema.coerce_data(pd.DataFrame([{"number": 2}]))
         assert data.loc[0, "Text"] == ""  # default value should be set
+        assert data.loc[0, "Integer"] == 1
+        assert data.loc[0, "Array"] == [
+            "test",
+            "test again",
+        ]  # default value should be set
+        assert data.loc[0, "Dictionary"] == {"test": "test"}
+        assert data.loc[0, "Date Time"] == "2020-01-01T00:00:00"
+        assert data.loc[0, "Boolean"] == True
+        assert pd.isna(data.loc[0, "Optional String"])
         assert data.loc[0, "Number"] == 2  # value passed should be set
 
     def test_grid_types(self):

--- a/tests/test_autogrid.py
+++ b/tests/test_autogrid.py
@@ -310,6 +310,20 @@ class TestGridSchema:
             ].values()
         ]
 
+    def test_coerce_data_set_default_values(self):
+        class Test(BaseModel):
+            text: str = ""
+            number: float
+
+        class TestDataFrame(RootModel):
+            root: ty.List[Test] = Field(format="dataframe")
+
+        model, schema = _init_model_schema(TestDataFrame)
+        gridschema = GridSchema(schema)
+        data = gridschema.coerce_data(pd.DataFrame([{"number": 2}]))
+        assert data.loc[0, "Text"] == ""  # default value should be set
+        assert data.loc[0, "Number"] == 2  # value passed should be set
+
     def test_grid_types(self):
         class TestProperties(BaseModel):
             stringy: str


### PR DESCRIPTION
If key-value pair missing in value passed to GridSchema, then use the default value as defined in the schema when coercing the data.