### PR TITLE
🐛 Set `merge_props` to True when using `replace_refs`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "numpy",
     "openpyxl",
     "pandas",
-    "pydantic<2.9",
+    "pydantic>=2.9",
     "pydantic-settings",
     "pydantic-extra-types",
     "PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "numpy",
     "openpyxl",
     "pandas",
-    "pydantic>=2.9",
+    "pydantic>=2",
     "pydantic-settings",
     "pydantic-extra-types",
     "PyYAML",

--- a/src/ipyautoui/automapschema.py
+++ b/src/ipyautoui/automapschema.py
@@ -51,7 +51,7 @@ def _init_model_schema(
         model = schema  # the "model" passed is a pydantic model
         schema = model.model_json_schema(by_alias=by_alias).copy()
 
-    schema = replace_refs(schema)
+    schema = replace_refs(schema, merge_props=True)
     schema = {k: v for k, v in schema.items() if k != "$defs"}
     return model, schema
 
@@ -1321,7 +1321,7 @@ def from_schema_method(
 ):
     if "$defs" in schema.keys():
         try:
-            schema = replace_refs(schema)
+            schema = replace_refs(schema, merge_props=True)
         except ValueError as e:
             logger.warning(f"replace_refs error: \n{e}")
             pass
@@ -1331,7 +1331,7 @@ def from_schema_method(
 
 
 def from_model_method(cls, model: ty.Type[BaseModel], value: ty.Optional[dict] = None):
-    schema = replace_refs(model.model_json_schema())
+    schema = replace_refs(model.model_json_schema(), merge_props=True)
     if value is not None:
         schema["value"] = value
     ui = cls(**schema)

--- a/src/ipyautoui/autoobject.py
+++ b/src/ipyautoui/autoobject.py
@@ -487,7 +487,7 @@ if __name__ == "__main__":
         "text_short": "short text",
         "textarea": "long text long text " * 20,
     }
-    s = replace_refs(CoreIpywidgets.model_json_schema())
+    s = replace_refs(CoreIpywidgets.model_json_schema(), merge_props=True)
     # s["align_horizontal"] = False
     s["order_can_hide_rows"] = True
     s["order"] = ["int_slider_req", "dropdown_int", "int_range_slider_disabled"]
@@ -503,7 +503,7 @@ if __name__ == "__main__":
 if __name__ == "__main__":
     from ipyautoui.demo_schemas import NestedEditableGrid, ComplexSerialisation
 
-    s = replace_refs(NestedEditableGrid.model_json_schema())
+    s = replace_refs(NestedEditableGrid.model_json_schema(), merge_props=True)
     s["order_can_hide_rows"] = False
     s["open_nested"] = True
     ui = AutoObject.from_jsonschema(s)
@@ -512,7 +512,7 @@ if __name__ == "__main__":
 if __name__ == "__main__":
     from ipyautoui.demo_schemas import NestedEditableGrid, ComplexSerialisation
 
-    s = replace_refs(ComplexSerialisation.model_json_schema())
+    s = replace_refs(ComplexSerialisation.model_json_schema(), merge_props=True)
     s["order_can_hide_rows"] = False
     ui = AutoObject.from_jsonschema(s)
     display(ui)
@@ -543,7 +543,7 @@ if __name__ == "__main__":
         "text_short": "short text",
         "textarea": "long text long text" * 20,
     }
-    s = replace_refs(CoreIpywidgets.model_json_schema())
+    s = replace_refs(CoreIpywidgets.model_json_schema(), merge_props=True)
     # s["align_horizontal"] = False
     s["order_can_hide_rows"] = False
     ui = AutoObject.from_jsonschema(s, value=v)

--- a/src/ipyautoui/custom/iterable.py
+++ b/src/ipyautoui/custom/iterable.py
@@ -567,7 +567,7 @@ if __name__ == "__main__":
 
         root: list[MyObject]
 
-    s = replace_refs(ArrayWithUnionType.model_json_schema())
+    s = replace_refs(ArrayWithUnionType.model_json_schema(), merge_props=True)
     v = MyObject(floaty=0.2).model_dump()
     s["value"] = [v]
     ui = AutoArrayForm.from_schema(s)
@@ -590,7 +590,7 @@ if __name__ == "__main__":
 
         root: list[MyObject]
 
-    s = replace_refs(ArrayWithUnionType.model_json_schema())
+    s = replace_refs(ArrayWithUnionType.model_json_schema(), merge_props=True)
     v = MyObject(floaty=0.2).model_dump()
     s["value"] = [v]
     ui = AutoArrayForm.from_schema(s)
@@ -613,7 +613,7 @@ if __name__ == "__main__":
 
         root: list[ty.Union[MyArray, MyObject]]
 
-    s = replace_refs(MyArray.model_json_schema())
+    s = replace_refs(MyArray.model_json_schema(), merge_props=True)
     ui = AutoArray(**s)
     display(ui)
 

--- a/src/ipyautoui/watch_validate.py
+++ b/src/ipyautoui/watch_validate.py
@@ -152,7 +152,7 @@ class WatchValidate(tr.HasTraits):  # TODO: _WatchValidate
             model = None
             if "$defs" in schema.keys():
                 try:
-                    schema = replace_refs(schema)
+                    schema = replace_refs(schema, merge_props=True)
                     schema = {k: v for k, v in schema.items() if k != "$defs"}
                 except ValueError as e:
                     logger.warning(f"replace_refs error: \n{e}")
@@ -171,9 +171,10 @@ class WatchValidate(tr.HasTraits):  # TODO: _WatchValidate
         if not (issubclass(model, BaseModel) or issubclass(model, RootModel)):
             raise ValueError(f"schema must be a pydantic model, not {type(model)}")
         else:
+            schema = model.model_json_schema(by_alias=by_alias)
             if "by_alias" in kwargs.keys():
                 by_alias = kwargs["by_alias"]
-            schema = replace_refs(model.model_json_schema(by_alias=by_alias))
+            schema = replace_refs(schema, merge_props=True)
             schema = {k: v for k, v in schema.items() if k != "$defs"}
         if value is not None:
             schema["value"] = value

--- a/tests/test_autogrid.py
+++ b/tests/test_autogrid.py
@@ -754,7 +754,7 @@ class TestAutoGrid:
             schema=TestDataFrame.model_json_schema(),
             data=pd.DataFrame([{"string": "Test"}] * 10),
         )
-        json_schema = jsonref.replace_refs(TestDataFrame.model_json_schema())
+        json_schema = jsonref.replace_refs(TestDataFrame.model_json_schema(), merge_props=True)
         import copy
 
         # Make deep copies to avoid modifying the original dictionaries

--- a/tests/test_autogrid.py
+++ b/tests/test_autogrid.py
@@ -754,7 +754,9 @@ class TestAutoGrid:
             schema=TestDataFrame.model_json_schema(),
             data=pd.DataFrame([{"string": "Test"}] * 10),
         )
-        json_schema = jsonref.replace_refs(TestDataFrame.model_json_schema(), merge_props=True)
+        json_schema = jsonref.replace_refs(
+            TestDataFrame.model_json_schema(), merge_props=True
+        )
         import copy
 
         # Make deep copies to avoid modifying the original dictionaries

--- a/tests/test_automapschema.py
+++ b/tests/test_automapschema.py
@@ -131,7 +131,7 @@ def test_union():
         inty: int = 1
         floaty: ty.Union[float, str] = 1.5
 
-    di = replace_refs(MyObject.model_json_schema())
+    di = replace_refs(MyObject.model_json_schema(), merge_props=True)
     caller = map_widget(di)
     assert "anyOf" in caller.kwargs["properties"]["floaty"]
     ui = widgetcaller(caller)

--- a/tests/test_editgrid.py
+++ b/tests/test_editgrid.py
@@ -159,7 +159,7 @@ class TestEditGrid:
         editgrid.update_from_schema(TestDataFrame, value=[{"string": "Test"}] * 10)
         import jsonref
 
-        json_schema = jsonref.replace_refs(TestDataFrame.model_json_schema())
+        json_schema = jsonref.replace_refs(TestDataFrame.model_json_schema(), merge_props=True)
         import copy
 
         # Make deep copies to avoid modifying the original dictionaries

--- a/tests/test_editgrid.py
+++ b/tests/test_editgrid.py
@@ -159,7 +159,9 @@ class TestEditGrid:
         editgrid.update_from_schema(TestDataFrame, value=[{"string": "Test"}] * 10)
         import jsonref
 
-        json_schema = jsonref.replace_refs(TestDataFrame.model_json_schema(), merge_props=True)
+        json_schema = jsonref.replace_refs(
+            TestDataFrame.model_json_schema(), merge_props=True
+        )
         import copy
 
         # Make deep copies to avoid modifying the original dictionaries


### PR DESCRIPTION
The JSON schema specification has been updated to allow sibling keys alongside `$ref` keys so it is no longer required to wrap the `$ref` key in an `allOf` array with a single `$ref` element. The method `model_json_schema` has been updated in Pydantic 2.9 to reflect this logic.

This means that the JSON schema specification does not adhere to the [jsonref specification](http://jsonref.org/#ref) anymore which states:

`All other properties of an object containing a $ref key are ignored.`

By setting `merge_props=True`, the jsonref `replace_refs` ignores this specific part of the jsonref spec.

Reference issue in `jsonref` repository: https://github.com/gazpachoking/jsonref/issues/68