### PR TITLE
BUGFIX-editgrid-set-order-clears-grid

### DIFF
--- a/docs/demo.ipynb
+++ b/docs/demo.ipynb
@@ -63,7 +63,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c43bffc73c4a47a0bda87472c95480ee",
+       "model_id": "f7bf2a6630fe49d68d848b2c248e9d0a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -98,7 +98,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.7"
   },
   "vscode": {
    "interpreter": {

--- a/pixi.lock
+++ b/pixi.lock
@@ -197,17 +197,23 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2b/c9/1c8fe3ce05d30c87eff498592c89015b19fade13df42850aafae09e94f35/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/82/72403624f197af0db6bac4e58153bc9ac0e6020e57234115db9596eee85d/cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/87/2b/3b7a00d8d2bb891cfa33240575c2d5fc3fa6e0bc75567f4ece59b9d3d6ea/debugpy-1.8.9-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/90/2b/0817a2b257fe88725c25589d89aec060581aabf668707a8d03b2e9e0cb2a/fastjsonschema-2.21.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/48/583c032b79ae5b3daa02225a675aeb673e58d2cb698e78510feceb11958c/gast-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/8d/6d965a22bc38cec091ba82131624bb5d75471094d7fe05e829536de3de2f/hatch-1.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/72/41/b3e29dc4fe623794070e5dfbb9915acb649ce05d6472f005470cbed9de83/hatchling-1.26.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/fb/a19866137577ba60c6d8b69498dc36be479b13ba454f691348ddf428f185/httpx-0.28.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/a5/5fda0ee4a261a85124011ac0750fec678f00e1b2d4a5502b149a3b4d86d9/immutables-0.21-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
@@ -219,7 +225,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e4/1e/c2e7b4ae5cb88be0f898579c2ce35cd4efae28783a805b0016bc0115a49a/ipyvuetify-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/2d/9c0b76f2f9cc0ebede1b9371b6f317243028ed60b90705863d493bae622e/ipywidgets-8.1.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/aa/42/797895b952b682c3dafe23b1834507ee7f02f4d6299b65aaa61425763278/json5-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl
@@ -236,11 +246,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/09/2032e7d15c544a0e3cd831c51d77a8ca57f7555b2e1b2922142eddb02a84/jupyterlab_server-2.27.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/93/858e87edc634d628e5d752ba944c2833133a28fa87bb093e6832ced36a3e/jupyterlab_widgets-3.0.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/c9/353c156fa2f057e669106e5d6bcdecf85ef8d3536ce68ca96f18dc7b6d6f/keyring-25.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/d2/392229b44bd029731a187a259d3903f72a034f96a4f8147efe7a203363ba/maplocal-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/08/83871f3c50fc983b88547c196d11cf8c3340e37c32d2e9d6152abe2c61f7/Markdown-3.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/74/c95adcdf032956d9ef6c89a9b8a5152bf73915f8c633f3e3d88d06bd699c/mistune-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/7e/3a64597054a70f7c86eb0a7d4fc315b8c1ab932f64883a297bdffeb5f967/more_itertools-10.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/1a/ed6d1299b1a00c1af4a033fdee565f533926d819e084caf0d2832f6f87c6/nbclient-0.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/bb/bb5b6a515d1584aa2fd89965b11db6632e4bdc69495a52374bcc36e56cfa/nbconvert-7.16.4-py3-none-any.whl
@@ -282,10 +296,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/fc/403e65e56f65fff25f2973216974976d3f0a5c3f30e53758589b6dc9b79b/rpds_py-0.22.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/27/96d10863accf76a9c97baceac30b0a52d917eb985a8ac058bd4636aeede0/ruff-0.8.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/b0/4562db6223154aa4e22f939003cb92514c79f3d4dccca3444253fd17f902/Send2Trash-1.8.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/21/47d163f615df1d30c094f6c8bbb353619274edccf0327b185cc2493c2c33/setuptools-75.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/c2/fe97d779f3ef3b15f05c94a2f1e3d21732574ed441687474db9d342a7315/soupsieve-2.6-py3-none-any.whl
@@ -293,20 +310,27 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f3/1f/1241aa3d66e8dc1612427b17885f5fcd9c9ee3079fc0d28e9a3aeeb36fa3/stringcase-1.2.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/ac/ce90573ba446a9bbe65838ded066a805234d159b4446ae9f8ec5bbd36cbd/tomli_w-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/55/b78a464de78051a30599ceb6983b01d8f732e6f69bf37b4ed07f642ac0fc/tornado-6.4.2-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9c/d1/8d5bd662703cc1764d986f6908a608777305946fa634d34c470cd4a1e729/traittypes-0.2.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/35/35/5055ab8d215af853d07bbff1a74edf48f91ed308f037380a5ca52dd73348/trove_classifiers-2024.10.21.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/b3/ca41df24db5eb99b00d97f89d7674a90cb6b3134c52fb8121b6d8d30f15c/types_python_dateutil-2.9.0.20241206-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/ab/7e5f53c3b9d14972843a647d8d7a853969a58aecc7559cb3267302c94774/tzdata-2024.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/59/52/d7c8baab385fcfd8da93065e42993a4d0d57a97e600ab3c7b3de83f63e57/uv-0.5.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/10/f9/0919cf6f1432a8c4baa62511f8f8da8225432d22e83e3476f5be1a1edc6e/virtualenv-20.28.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/df/4ee467ab39cc1de4b852c212c1ed3becfec2e486a51ac1ce0091f85f38d7/wcmatch-10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/e8/c0e05e4684d13459f93d312077a9a2efbe04d59c393bc2b8802248c908d4/webcolors-24.11.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/21/02/88b65cc394961a60c43c70517066b6b679738caf78506a5da7b88ffcb643/widgetsnbextension-4.0.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fa/18/89ac62eac46b69948bf35fcd90d37103f38722968e2981f752d69081ec4d/zstandard-0.23.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: .
 packages:
 - kind: conda
@@ -633,6 +657,35 @@ packages:
   - pytest ; extra == 'test'
   requires_python: '>=3.8'
 - kind: pypi
+  name: cryptography
+  version: 44.0.0
+  url: https://files.pythonhosted.org/packages/ef/82/72403624f197af0db6bac4e58153bc9ac0e6020e57234115db9596eee85d/cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl
+  sha256: f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7
+  requires_dist:
+  - cffi>=1.12 ; platform_python_implementation != 'PyPy'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  - nox>=2024.4.15 ; extra == 'nox'
+  - nox[uv]>=2024.3.2 ; python_full_version >= '3.8' and extra == 'nox'
+  - cryptography-vectors==44.0.0 ; extra == 'test'
+  - pytest>=7.4.0 ; extra == 'test'
+  - pytest-benchmark>=4.0 ; extra == 'test'
+  - pytest-cov>=2.10.1 ; extra == 'test'
+  - pytest-xdist>=3.5.0 ; extra == 'test'
+  - pretend>=0.7 ; extra == 'test'
+  - certifi>=2024 ; extra == 'test'
+  - pytest-randomly ; extra == 'test-randomorder'
+  - sphinx>=5.3.0 ; extra == 'docs'
+  - sphinx-rtd-theme>=3.0.0 ; python_full_version >= '3.8' and extra == 'docs'
+  - pyenchant>=3 ; extra == 'docstest'
+  - readme-renderer>=30.0 ; extra == 'docstest'
+  - sphinxcontrib-spelling>=7.3.1 ; extra == 'docstest'
+  - build>=1.0.0 ; extra == 'sdist'
+  - ruff>=0.3.6 ; extra == 'pep8test'
+  - mypy>=1.4 ; extra == 'pep8test'
+  - check-sdist ; python_full_version >= '3.8' and extra == 'pep8test'
+  - click>=8.0.1 ; extra == 'pep8test'
+  requires_python: '>=3.7,!=3.9.0,!=3.9.1'
+- kind: pypi
   name: debugpy
   version: 1.8.9
   url: https://files.pythonhosted.org/packages/87/2b/3b7a00d8d2bb891cfa33240575c2d5fc3fa6e0bc75567f4ece59b9d3d6ea/debugpy-1.8.9-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -650,6 +703,11 @@ packages:
   url: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
   sha256: a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*'
+- kind: pypi
+  name: distlib
+  version: 0.3.9
+  url: https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl
+  sha256: 47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87
 - kind: pypi
   name: et-xmlfile
   version: 2.0.0
@@ -685,6 +743,26 @@ packages:
   - pytest-cache ; extra == 'devel'
   - validictory ; extra == 'devel'
 - kind: pypi
+  name: filelock
+  version: 3.16.1
+  url: https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl
+  sha256: 2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0
+  requires_dist:
+  - furo>=2024.8.6 ; extra == 'docs'
+  - sphinx-autodoc-typehints>=2.4.1 ; extra == 'docs'
+  - sphinx>=8.0.2 ; extra == 'docs'
+  - covdefaults>=2.3 ; extra == 'testing'
+  - coverage>=7.6.1 ; extra == 'testing'
+  - diff-cover>=9.2 ; extra == 'testing'
+  - pytest-asyncio>=0.24 ; extra == 'testing'
+  - pytest-cov>=5 ; extra == 'testing'
+  - pytest-mock>=3.14 ; extra == 'testing'
+  - pytest-timeout>=2.3.1 ; extra == 'testing'
+  - pytest>=8.3.3 ; extra == 'testing'
+  - virtualenv>=20.26.4 ; extra == 'testing'
+  - typing-extensions>=4.12.2 ; python_full_version < '3.11' and extra == 'typing'
+  requires_python: '>=3.8'
+- kind: pypi
   name: fqdn
   version: 1.5.1
   url: https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl
@@ -706,6 +784,41 @@ packages:
   requires_dist:
   - typing-extensions ; python_full_version < '3.8'
   requires_python: '>=3.7'
+- kind: pypi
+  name: hatch
+  version: 1.13.0
+  url: https://files.pythonhosted.org/packages/13/8d/6d965a22bc38cec091ba82131624bb5d75471094d7fe05e829536de3de2f/hatch-1.13.0-py3-none-any.whl
+  sha256: bb1a18558a626279cae338b4d8a9d3ca4226d5e06d50de600608c57acd131b67
+  requires_dist:
+  - click>=8.0.6
+  - hatchling>=1.24.2
+  - httpx>=0.22.0
+  - hyperlink>=21.0.0
+  - keyring>=23.5.0
+  - packaging>=23.2
+  - pexpect~=4.8
+  - platformdirs>=2.5.0
+  - rich>=11.2.0
+  - shellingham>=1.4.0
+  - tomli-w>=1.0
+  - tomlkit>=0.11.1
+  - userpath~=1.7
+  - uv>=0.1.35
+  - virtualenv>=20.26.1
+  - zstandard<1
+  requires_python: '>=3.8'
+- kind: pypi
+  name: hatchling
+  version: 1.26.3
+  url: https://files.pythonhosted.org/packages/72/41/b3e29dc4fe623794070e5dfbb9915acb649ce05d6472f005470cbed9de83/hatchling-1.26.3-py3-none-any.whl
+  sha256: c407e1c6c17b574584a66ae60e8e9a01235ecb6dc61d01559bb936577aaf5846
+  requires_dist:
+  - packaging>=24.2
+  - pathspec>=0.10.1
+  - pluggy>=1.0.0
+  - tomli>=1.2.2 ; python_full_version < '3.11'
+  - trove-classifiers
+  requires_python: '>=3.8'
 - kind: pypi
   name: httpcore
   version: 1.0.7
@@ -739,6 +852,15 @@ packages:
   - zstandard>=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.8'
 - kind: pypi
+  name: hyperlink
+  version: 21.0.0
+  url: https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl
+  sha256: e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4
+  requires_dist:
+  - idna>=2.5
+  - typing ; python_full_version < '3.5'
+  requires_python: '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+- kind: pypi
   name: idna
   version: '3.10'
   url: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
@@ -768,9 +890,9 @@ packages:
   requires_python: '>=3.7'
 - kind: pypi
   name: ipyautoui
-  version: 0.7.21.dev7+g4fffa92.d20241206
+  version: 0.7.21.dev16+gbe194c8
   path: .
-  sha256: 95ef58e448830b6741950ec9d9c13cb5684134ed20c59231f0f36f4a00034397
+  sha256: f290bbf2c64d5781a08a573ed3a6e286fc94ea3e32facba29e59d70a2a40aafb
   requires_dist:
   - immutables
   - ipydatagrid>=1.3.2
@@ -790,6 +912,7 @@ packages:
   - pyyaml
   - stringcase
   - wcmatch
+  - hatch ; extra == 'tests'
   - maplocal==0.2.1 ; extra == 'tests'
   - pytest ; extra == 'tests'
   - pytest-examples ; extra == 'tests'
@@ -966,6 +1089,68 @@ packages:
   - arrow>=0.15.0
   requires_python: '>=3.7'
 - kind: pypi
+  name: jaraco-classes
+  version: 3.4.0
+  url: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
+  sha256: f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790
+  requires_dist:
+  - more-itertools
+  - sphinx>=3.5 ; extra == 'docs'
+  - jaraco-packaging>=9.3 ; extra == 'docs'
+  - rst-linker>=1.9 ; extra == 'docs'
+  - furo ; extra == 'docs'
+  - sphinx-lint ; extra == 'docs'
+  - jaraco-tidelift>=1.4 ; extra == 'docs'
+  - pytest>=6 ; extra == 'testing'
+  - pytest-checkdocs>=2.4 ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-mypy ; extra == 'testing'
+  - pytest-enabler>=2.2 ; extra == 'testing'
+  - pytest-ruff>=0.2.1 ; extra == 'testing'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: jaraco-context
+  version: 6.0.1
+  url: https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl
+  sha256: f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4
+  requires_dist:
+  - backports-tarfile ; python_full_version < '3.12'
+  - sphinx>=3.5 ; extra == 'doc'
+  - jaraco-packaging>=9.3 ; extra == 'doc'
+  - rst-linker>=1.9 ; extra == 'doc'
+  - furo ; extra == 'doc'
+  - sphinx-lint ; extra == 'doc'
+  - jaraco-tidelift>=1.4 ; extra == 'doc'
+  - pytest!=8.1.*,>=6 ; extra == 'test'
+  - pytest-checkdocs>=2.4 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-mypy ; extra == 'test'
+  - pytest-enabler>=2.2 ; extra == 'test'
+  - portend ; extra == 'test'
+  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'test'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: jaraco-functools
+  version: 4.1.0
+  url: https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl
+  sha256: ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649
+  requires_dist:
+  - more-itertools
+  - pytest-checkdocs>=2.4 ; extra == 'check'
+  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
+  - pytest-cov ; extra == 'cover'
+  - sphinx>=3.5 ; extra == 'doc'
+  - jaraco-packaging>=9.3 ; extra == 'doc'
+  - rst-linker>=1.9 ; extra == 'doc'
+  - furo ; extra == 'doc'
+  - sphinx-lint ; extra == 'doc'
+  - jaraco-tidelift>=1.4 ; extra == 'doc'
+  - pytest-enabler>=2.2 ; extra == 'enabler'
+  - pytest!=8.1.*,>=6 ; extra == 'test'
+  - jaraco-classes ; extra == 'test'
+  - pytest-mypy ; extra == 'type'
+  requires_python: '>=3.8'
+- kind: pypi
   name: jedi
   version: 0.19.2
   url: https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl
@@ -1006,6 +1191,21 @@ packages:
   - docopt ; extra == 'testing'
   - pytest<9.0.0 ; extra == 'testing'
   requires_python: '>=3.6'
+- kind: pypi
+  name: jeepney
+  version: 0.8.0
+  url: https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl
+  sha256: c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755
+  requires_dist:
+  - pytest ; extra == 'test'
+  - pytest-trio ; extra == 'test'
+  - pytest-asyncio>=0.17 ; extra == 'test'
+  - testpath ; extra == 'test'
+  - trio ; extra == 'test'
+  - async-timeout ; extra == 'test'
+  - trio ; extra == 'trio'
+  - async-generator ; python_full_version == '3.6.*' and extra == 'trio'
+  requires_python: '>=3.7'
 - kind: pypi
   name: jinja2
   version: 3.1.4
@@ -1353,6 +1553,38 @@ packages:
   url: https://files.pythonhosted.org/packages/a9/93/858e87edc634d628e5d752ba944c2833133a28fa87bb093e6832ced36a3e/jupyterlab_widgets-3.0.13-py3-none-any.whl
   sha256: e3cda2c233ce144192f1e29914ad522b2f4c40e77214b0cc97377ca3d323db54
   requires_python: '>=3.7'
+- kind: pypi
+  name: keyring
+  version: 25.5.0
+  url: https://files.pythonhosted.org/packages/32/c9/353c156fa2f057e669106e5d6bcdecf85ef8d3536ce68ca96f18dc7b6d6f/keyring-25.5.0-py3-none-any.whl
+  sha256: e67f8ac32b04be4714b42fe84ce7dad9c40985b9ca827c592cc303e7c26d9741
+  requires_dist:
+  - jaraco-classes
+  - jaraco-functools
+  - jaraco-context
+  - importlib-metadata>=4.11.4 ; python_full_version < '3.12'
+  - importlib-resources ; python_full_version < '3.9'
+  - secretstorage>=3.2 ; sys_platform == 'linux'
+  - jeepney>=0.4.2 ; sys_platform == 'linux'
+  - pywin32-ctypes>=0.2.0 ; sys_platform == 'win32'
+  - pytest-checkdocs>=2.4 ; extra == 'check'
+  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
+  - shtab>=1.1.0 ; extra == 'completion'
+  - pytest-cov ; extra == 'cover'
+  - sphinx>=3.5 ; extra == 'doc'
+  - jaraco-packaging>=9.3 ; extra == 'doc'
+  - rst-linker>=1.9 ; extra == 'doc'
+  - furo ; extra == 'doc'
+  - sphinx-lint ; extra == 'doc'
+  - jaraco-tidelift>=1.4 ; extra == 'doc'
+  - pytest-enabler>=2.2 ; extra == 'enabler'
+  - pytest!=8.1.*,>=6 ; extra == 'test'
+  - pyfakefs ; extra == 'test'
+  - pytest-mypy ; extra == 'type'
+  - pygobject-stubs ; extra == 'type'
+  - shtab ; extra == 'type'
+  - types-pywin32 ; extra == 'type'
+  requires_python: '>=3.8'
 - kind: conda
   name: ld_impl_linux-64
   version: '2.43'
@@ -1567,6 +1799,38 @@ packages:
   - pyyaml ; extra == 'testing'
   requires_python: '>=3.8'
 - kind: pypi
+  name: markdown-it-py
+  version: 3.0.0
+  url: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
+  sha256: 355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1
+  requires_dist:
+  - mdurl~=0.1
+  - psutil ; extra == 'benchmarking'
+  - pytest ; extra == 'benchmarking'
+  - pytest-benchmark ; extra == 'benchmarking'
+  - pre-commit~=3.0 ; extra == 'code-style'
+  - commonmark~=0.9 ; extra == 'compare'
+  - markdown~=3.4 ; extra == 'compare'
+  - mistletoe~=1.0 ; extra == 'compare'
+  - mistune~=2.0 ; extra == 'compare'
+  - panflute~=2.3 ; extra == 'compare'
+  - linkify-it-py>=1,<3 ; extra == 'linkify'
+  - mdit-py-plugins ; extra == 'plugins'
+  - gprof2dot ; extra == 'profiling'
+  - mdit-py-plugins ; extra == 'rtd'
+  - myst-parser ; extra == 'rtd'
+  - pyyaml ; extra == 'rtd'
+  - sphinx ; extra == 'rtd'
+  - sphinx-copybutton ; extra == 'rtd'
+  - sphinx-design ; extra == 'rtd'
+  - sphinx-book-theme ; extra == 'rtd'
+  - jupyter-sphinx ; extra == 'rtd'
+  - coverage ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-regressions ; extra == 'testing'
+  requires_python: '>=3.8'
+- kind: pypi
   name: markupsafe
   version: 3.0.2
   url: https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -1581,11 +1845,23 @@ packages:
   - traitlets
   requires_python: '>=3.8'
 - kind: pypi
+  name: mdurl
+  version: 0.1.2
+  url: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+  sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+  requires_python: '>=3.7'
+- kind: pypi
   name: mistune
   version: 3.0.2
   url: https://files.pythonhosted.org/packages/f0/74/c95adcdf032956d9ef6c89a9b8a5152bf73915f8c633f3e3d88d06bd699c/mistune-3.0.2-py3-none-any.whl
   sha256: 71481854c30fdbc938963d3605b72501f5c10a9320ecd412c121c163a1c7d205
   requires_python: '>=3.7'
+- kind: pypi
+  name: more-itertools
+  version: 10.5.0
+  url: https://files.pythonhosted.org/packages/48/7e/3a64597054a70f7c86eb0a7d4fc315b8c1ab932f64883a297bdffeb5f967/more_itertools-10.5.0-py3-none-any.whl
+  sha256: 037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef
+  requires_python: '>=3.8'
 - kind: pypi
   name: mypy-extensions
   version: 1.0.0
@@ -2241,6 +2517,17 @@ packages:
   sha256: 2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*'
 - kind: pypi
+  name: rich
+  version: 13.9.4
+  url: https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl
+  sha256: 6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90
+  requires_dist:
+  - ipywidgets>=7.5.1,<9 ; extra == 'jupyter'
+  - markdown-it-py>=2.2.0
+  - pygments>=2.13.0,<3.0.0
+  - typing-extensions>=4.0.0,<5.0 ; python_full_version < '3.11'
+  requires_python: '>=3.8.0'
+- kind: pypi
   name: rpds-py
   version: 0.22.3
   url: https://files.pythonhosted.org/packages/27/fc/403e65e56f65fff25f2973216974976d3f0a5c3f30e53758589b6dc9b79b/rpds_py-0.22.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -2252,6 +2539,15 @@ packages:
   url: https://files.pythonhosted.org/packages/a9/27/96d10863accf76a9c97baceac30b0a52d917eb985a8ac058bd4636aeede0/ruff-0.8.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 5fe716592ae8a376c2673fdfc1f5c0c193a6d0411f90a496863c99cd9e2ae25d
   requires_python: '>=3.7'
+- kind: pypi
+  name: secretstorage
+  version: 3.3.3
+  url: https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl
+  sha256: f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99
+  requires_dist:
+  - cryptography>=2.0
+  - jeepney>=0.6
+  requires_python: '>=3.6'
 - kind: pypi
   name: send2trash
   version: 1.8.3
@@ -2323,6 +2619,12 @@ packages:
   - importlib-metadata>=7.0.2 ; python_full_version < '3.10' and extra == 'type'
   - jaraco-develop>=7.21 ; sys_platform != 'cygwin' and extra == 'type'
   requires_python: '>=3.9'
+- kind: pypi
+  name: shellingham
+  version: 1.5.4
+  url: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+  sha256: 7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686
+  requires_python: '>=3.7'
 - kind: pypi
   name: six
   version: 1.17.0
@@ -2408,6 +2710,18 @@ packages:
   size: 3318875
   timestamp: 1699202167581
 - kind: pypi
+  name: tomli-w
+  version: 1.1.0
+  url: https://files.pythonhosted.org/packages/c4/ac/ce90573ba446a9bbe65838ded066a805234d159b4446ae9f8ec5bbd36cbd/tomli_w-1.1.0-py3-none-any.whl
+  sha256: 1403179c78193e3184bfaade390ddbd071cba48a32a2e62ba11aae47490c63f7
+  requires_python: '>=3.9'
+- kind: pypi
+  name: tomlkit
+  version: 0.13.2
+  url: https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl
+  sha256: 7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde
+  requires_python: '>=3.8'
+- kind: pypi
   name: tornado
   version: 6.4.2
   url: https://files.pythonhosted.org/packages/22/55/b78a464de78051a30599ceb6983b01d8f732e6f69bf37b4ed07f642ac0fc/tornado-6.4.2-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -2440,6 +2754,11 @@ packages:
   - pandas ; extra == 'test'
   - xarray ; extra == 'test'
   - pytest ; extra == 'test'
+- kind: pypi
+  name: trove-classifiers
+  version: 2024.10.21.16
+  url: https://files.pythonhosted.org/packages/35/35/5055ab8d215af853d07bbff1a74edf48f91ed308f037380a5ca52dd73348/trove_classifiers-2024.10.21.16-py3-none-any.whl
+  sha256: 0fb11f1e995a757807a8ef1c03829fbd4998d817319abcef1f33165750f103be
 - kind: pypi
   name: types-python-dateutil
   version: 2.9.0.20241206
@@ -2511,6 +2830,50 @@ packages:
   - zstandard>=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.8'
 - kind: pypi
+  name: userpath
+  version: 1.9.2
+  url: https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl
+  sha256: 2cbf01a23d655a1ff8fc166dfb78da1b641d1ceabf0fe5f970767d380b14e89d
+  requires_dist:
+  - click
+  requires_python: '>=3.7'
+- kind: pypi
+  name: uv
+  version: 0.5.6
+  url: https://files.pythonhosted.org/packages/59/52/d7c8baab385fcfd8da93065e42993a4d0d57a97e600ab3c7b3de83f63e57/uv-0.5.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 920dd926d235f826454e7b68cb1890ded6e67510e6195c346eef41caabc9d9b7
+  requires_python: '>=3.8'
+- kind: pypi
+  name: virtualenv
+  version: 20.28.0
+  url: https://files.pythonhosted.org/packages/10/f9/0919cf6f1432a8c4baa62511f8f8da8225432d22e83e3476f5be1a1edc6e/virtualenv-20.28.0-py3-none-any.whl
+  sha256: 23eae1b4516ecd610481eda647f3a7c09aea295055337331bb4e6892ecce47b0
+  requires_dist:
+  - distlib<1,>=0.3.7
+  - filelock<4,>=3.12.2
+  - importlib-metadata>=6.6 ; python_full_version < '3.8'
+  - platformdirs<5,>=3.9.1
+  - furo>=2023.7.26 ; extra == 'docs'
+  - proselint>=0.13 ; extra == 'docs'
+  - sphinx!=7.3,>=7.1.2 ; extra == 'docs'
+  - sphinx-argparse>=0.4 ; extra == 'docs'
+  - sphinxcontrib-towncrier>=0.2.1a0 ; extra == 'docs'
+  - towncrier>=23.6 ; extra == 'docs'
+  - covdefaults>=2.3 ; extra == 'test'
+  - coverage-enable-subprocess>=1 ; extra == 'test'
+  - coverage>=7.2.7 ; extra == 'test'
+  - flaky>=3.7 ; extra == 'test'
+  - packaging>=23.1 ; extra == 'test'
+  - pytest-env>=0.8.2 ; extra == 'test'
+  - pytest-freezer>=0.4.8 ; (python_full_version >= '3.13' and platform_python_implementation == 'CPython' and sys_platform == 'win32' and extra == 'test') or (platform_python_implementation == 'PyPy' and extra == 'test')
+  - pytest-mock>=3.11.1 ; extra == 'test'
+  - pytest-randomly>=3.12 ; extra == 'test'
+  - pytest-timeout>=2.1 ; extra == 'test'
+  - pytest>=7.4 ; extra == 'test'
+  - setuptools>=68 ; extra == 'test'
+  - time-machine>=2.10 ; platform_python_implementation == 'CPython' and extra == 'test'
+  requires_python: '>=3.8'
+- kind: pypi
   name: wcmatch
   version: '10.0'
   url: https://files.pythonhosted.org/packages/ab/df/4ee467ab39cc1de4b852c212c1ed3becfec2e486a51ac1ce0091f85f38d7/wcmatch-10.0-py3-none-any.whl
@@ -2555,3 +2918,12 @@ packages:
   url: https://files.pythonhosted.org/packages/21/02/88b65cc394961a60c43c70517066b6b679738caf78506a5da7b88ffcb643/widgetsnbextension-4.0.13-py3-none-any.whl
   sha256: 74b2692e8500525cc38c2b877236ba51d34541e6385eeed5aec15a70f88a6c71
   requires_python: '>=3.7'
+- kind: pypi
+  name: zstandard
+  version: 0.23.0
+  url: https://files.pythonhosted.org/packages/fa/18/89ac62eac46b69948bf35fcd90d37103f38722968e2981f752d69081ec4d/zstandard-0.23.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 6f77fa49079891a4aab203d0b1744acc85577ed16d767b52fc089d83faf8d8ed
+  requires_dist:
+  - cffi>=1.17 ; platform_python_implementation == 'PyPy'
+  - cffi>=1.17 ; extra == 'cffi'
+  requires_python: '>=3.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
 tests = [
   "pytest",
   "maplocal==0.2.1",
-  "pytest_examples"
+  "pytest_examples",
+  "hatch"
 ]
 
 [project.urls]
@@ -73,6 +74,6 @@ tests = { features = ["tests"], solve-group = "default" }
 
 [tool.pixi.feature.tests.tasks]
 tests = "pytest"
-# check = "ruff check"
-# fix = "ruff check --fix --select I"
+check = "ruff check"
+build = "hatch build"
 # format = "ruff format"

--- a/src/ipyautoui/constants.py
+++ b/src/ipyautoui/constants.py
@@ -9,7 +9,6 @@ from ipyautoui._utils import frozenmap
 # https://github.com/MagicStack/immutables
 
 DIR_MODULE = pathlib.Path(__file__).parent
-DIR_EXAMPLE = DIR_MODULE.parents[1] / "examples"
 PATH_VJSF_TEMPLATE = DIR_MODULE / "vjsf.vue"
 PATH_SVG = DIR_MODULE / "data" / "12-dots-scale-rotate.svg"
 
@@ -236,7 +235,7 @@ KWARGS_HOME_DISPLAY_FILES = frozenmap(
 
 # documentinfo ------------------------------
 #  update this with WebApp data. TODO: delete this?
-ROLES = (
+ROLES = (  # TODO: delete from here - now in document_issue
     "Design Lead",
     "Project Engineer",
     "Engineer",

--- a/src/ipyautoui/custom/autogrid.py
+++ b/src/ipyautoui/custom/autogrid.py
@@ -445,7 +445,10 @@ class GridSchema:
 
         if len(col_names) < len(order):
             # add missing columns
-            data = data.reindex(columns=order)
+            if bykeys:
+                data = data.reindex(columns=order)
+            else:
+                data = data.reindex(columns=[self.map_name_index[x] for x in order])
 
         data = data.apply(fill_with_default)
 
@@ -1131,14 +1134,14 @@ if __name__ == "__main__":
     display(grid)
 
 # +
-# grid.selections
-
-# +
 if __name__ == "__main__":
     grid.data = pd.DataFrame(grid.data.to_dict(orient="records") * 4)  # .T
 
 if __name__ == "__main__":
     print(grid.is_transposed)
+# -
+
+
 
 # +
 if __name__ == "__main__":

--- a/src/ipyautoui/demo_schemas/override_ipywidgets.py
+++ b/src/ipyautoui/demo_schemas/override_ipywidgets.py
@@ -1,6 +1,6 @@
 from pydantic import Field
 from ipyautoui.basemodel import BaseModel
-
+import typing as ty
 
 class OverrideIpywidgets(BaseModel):
     """sometimes it isn't possible to guess what widget to use based on type information.
@@ -21,6 +21,12 @@ class OverrideIpywidgets(BaseModel):
     )
     toggle: bool = Field(
         default=True,
+        title="Toggle Button",
+        description="This is a toggle button, normally a checkbox is used for booleans.",
+        json_schema_extra=dict(autoui="ipywidgets.ToggleButton"),
+    )
+    nullable_toggle_overide: ty.Optional[bool] = Field(
+        default=None,
         title="Toggle Button",
         description="This is a toggle button, normally a checkbox is used for booleans.",
         json_schema_extra=dict(autoui="ipywidgets.ToggleButton"),

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -2,7 +2,9 @@ import pathlib
 
 DIR_TESTS = pathlib.Path(__file__).parent
 DIR_REPO = DIR_TESTS.parent
-PATH_TEST_AUI = DIR_TESTS / "testdata" / "test.aui.json"
+PATH_TEST_AUI = DIR_TESTS / "testdata" / "test.aui.json"  # TODO: delete
 DIR_FILETYPES = DIR_TESTS / "filetypes"
 DIR_DOCS = DIR_REPO / "docs"
 DIR_PACKAGE = DIR_REPO / "src" / "ipyautoui"
+
+PATH_INSTANCE_SPEC = DIR_TESTS / "instance_spec.json"

--- a/tests/instance_spec.json
+++ b/tests/instance_spec.json
@@ -1,0 +1,430 @@
+{
+    "data": [
+        {
+            "TypeMark": "ED-1",
+            "TypeSpecId": 1340,
+            "FuelType": "Electricity",
+            "EnergyConsumption": 100.0,
+            "InstanceReference": 1,
+            "ReportingPeriod": "2019/20",
+            "EnergyEndUse": "Heating",
+            "EnergyEndUseTags": "[]",
+            "Id": 142
+        },
+        {
+            "TypeMark": "ED-1",
+            "TypeSpecId": 1340,
+            "FuelType": "Electricity",
+            "EnergyConsumption": 100.0,
+            "InstanceReference": 3,
+            "ReportingPeriod": "2019/20",
+            "EnergyEndUse": "Heating",
+            "EnergyEndUseTags": "[]",
+            "Id": 158
+        },
+        {
+            "TypeMark": "ED-1",
+            "TypeSpecId": 1340,
+            "FuelType": "Electricity",
+            "EnergyConsumption": 0.0,
+            "InstanceReference": 4,
+            "ReportingPeriod": "2019/20",
+            "EnergyEndUse": "Heating",
+            "EnergyEndUseTags": "[]",
+            "Id": 159
+        },
+        {
+            "TypeMark": "ED-1",
+            "TypeSpecId": 1340,
+            "FuelType": "Electricity",
+            "BuildingID": "cxv",
+            "EnergyConsumption": 0.0,
+            "InstanceReference": 5,
+            "ReportingPeriod": "2019/20",
+            "EnergyEndUse": "Heating",
+            "EnergyEndUseTags": "[]",
+            "Id": 160
+        }
+    ],
+    "schema": {
+        "title": "Recorded Energy Use",
+        "type": "array",
+        "format": "DataFrame",
+        "hide_nan": true,
+        "datagrid_index_name": [
+            "section",
+            "title",
+            "unit"
+        ],
+        "items": {
+            "title": "Recorded Energy Use",
+            "description": "Recorded energy data (ED) consumed within the defined reporting period.",
+            "type": "object",
+            "parameter_type": "I",
+            "override_units": false,
+            "properties": {
+                "InstanceReference": {
+                    "type": "integer",
+                    "revit_data_type": "INTEGER",
+                    "ifc_data_type": "IfcInteger",
+                    "namespace_uri": null,
+                    "guid": "2705c5f3-e588-4d32-aac4-3bba358c898b",
+                    "guid_source": "MXF",
+                    "title": "Instance Reference",
+                    "name": "InstanceReference",
+                    "description": "equipment instance reference, integer only. Refers to equipment instance.",
+                    "json_schema_extra": {
+                        "default": 1
+                    },
+                    "category": "Specifications",
+                    "section": "Identity Data",
+                    "tooltip": "",
+                    "property_value_kind": "Single",
+                    "unit": "",
+                    "unit_code": "",
+                    "parameter_type": "I",
+                    "pset": "Pset_IdentityCore",
+                    "id": 2866,
+                    "default": 1
+                },
+                "Notes": {
+                    "revit_data_type": "TEXT",
+                    "ifc_data_type": "IfcText",
+                    "namespace_uri": null,
+                    "guid": "9faa8b0b-ab25-4dce-bb4d-3f8320522146",
+                    "guid_source": "MXF",
+                    "title": "Notes",
+                    "name": "Notes",
+                    "description": "",
+                    "json_schema_extra": null,
+                    "category": "Specifications",
+                    "section": "Application Data",
+                    "tooltip": "Additional information about the product",
+                    "property_value_kind": "Single",
+                    "unit": "",
+                    "unit_code": "",
+                    "parameter_type": "I",
+                    "pset": "EnergyRecord",
+                    "id": 2460,
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "FuelType": {
+                    "enum": [
+                        "Electricity",
+                        "Gas - NG",
+                        "Gas - Biogas",
+                        "Gas - LPG",
+                        "Gas - Other",
+                        "Unknown",
+                        "Unset"
+                    ],
+                    "revit_data_type": "TEXT",
+                    "ifc_data_type": "IfcText",
+                    "namespace_uri": null,
+                    "guid": "9c8c1fec-2d04-4340-9c08-2f250d319c8b",
+                    "guid_source": "BSDD",
+                    "title": "Fuel Type",
+                    "name": "FuelType",
+                    "description": "",
+                    "json_schema_extra": null,
+                    "category": "Specifications",
+                    "section": "Performance Data",
+                    "tooltip": "",
+                    "property_value_kind": "Single",
+                    "unit": "",
+                    "unit_code": "",
+                    "parameter_type": "I",
+                    "pset": "EnergyRecord",
+                    "id": 555,
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "EnergyConsumption": {
+                    "revit_data_type": "NUMBER",
+                    "ifc_data_type": "IfcReal",
+                    "namespace_uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/prop/EnergyConsumption",
+                    "guid": "8f737eae-19e8-4576-bca4-4982c4cf5a0a",
+                    "guid_source": "IFC",
+                    "title": "Energy Consumption",
+                    "name": "EnergyConsumption",
+                    "description": "Annual energy consumption requirement",
+                    "json_schema_extra": null,
+                    "category": "Specifications",
+                    "section": "Performance Data",
+                    "tooltip": null,
+                    "property_value_kind": "Single",
+                    "unit": "kWh/m2/yr",
+                    "unit_code": "hr*kW/(m**2*yr)",
+                    "parameter_type": "I",
+                    "pset": "EnergyRecord",
+                    "id": 1355,
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "EnergyEndUse": {
+                    "enum": [
+                        "Heating",
+                        "Domestic Hot Water",
+                        "Heating & Domestic Hot Water",
+                        "Cooling",
+                        "Auxiliary",
+                        "Lighting",
+                        "Small Power",
+                        "IT/Servers",
+                        "PV Generation",
+                        "Lifts",
+                        "Catering",
+                        "Other",
+                        "Unknown"
+                    ],
+                    "revit_data_type": "TEXT",
+                    "ifc_data_type": "IfcText",
+                    "namespace_uri": null,
+                    "guid": "3f92567b-3cec-4e91-9750-48eed59be231",
+                    "guid_source": "MXF",
+                    "title": "Energy End Use",
+                    "name": "EnergyEndUse",
+                    "description": "The end-use of the energy consumption within a building. Pick the most appropriate.",
+                    "json_schema_extra": null,
+                    "category": "Specifications",
+                    "section": "Performance Data",
+                    "tooltip": null,
+                    "property_value_kind": "Single",
+                    "unit": "",
+                    "unit_code": "",
+                    "parameter_type": "I",
+                    "pset": "EnergyRecord",
+                    "id": 3084,
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "EnergyEndUseTags": {
+                    "enum": [
+                        "Heating",
+                        "Heating - Distribution Loss",
+                        "Domestic Hot Water",
+                        "Cooling",
+                        "Auxiliary",
+                        "Lighting",
+                        "Lighting - External",
+                        "Small Power",
+                        "IT/Servers",
+                        "PV Generation",
+                        "Pool",
+                        "Lifts",
+                        "Catering",
+                        "Other",
+                        "Unknown"
+                    ],
+                    "revit_data_type": "TEXT",
+                    "ifc_data_type": "IfcText",
+                    "namespace_uri": null,
+                    "guid": "63e29ae5-d1d6-4e15-8215-e26c5cd02c9f",
+                    "guid_source": "MXF",
+                    "title": "Energy End Use Tags",
+                    "name": "EnergyEndUseTags",
+                    "description": "Additional tags to further describe the end-use of the energy where required, or to indicate energy use when \"Other\" or \"Unknown\" selected.",
+                    "json_schema_extra": null,
+                    "category": "Specifications",
+                    "section": "Performance Data",
+                    "tooltip": null,
+                    "property_value_kind": "Single",
+                    "unit": "",
+                    "unit_code": "",
+                    "parameter_type": "I",
+                    "pset": "EnergyRecord",
+                    "id": 3085,
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "ReportingPeriod": {
+                    "enum": [
+                        "2019/20",
+                        "2020/21",
+                        "2021/22",
+                        "2022/23",
+                        "2023/24",
+                        "2024/25",
+                        "2025/26",
+                        "2026/27",
+                        "2027/28",
+                        "2028/29",
+                        "2029/30",
+                        "Benchmark"
+                    ],
+                    "revit_data_type": "TEXT",
+                    "ifc_data_type": "IfcText",
+                    "namespace_uri": null,
+                    "guid": "399c7065-6e6a-4d7f-b412-903921ba6990",
+                    "guid_source": "MXF",
+                    "title": "Reporting Period",
+                    "name": "ReportingPeriod",
+                    "description": "Which year the energy record should be recorded in",
+                    "json_schema_extra": null,
+                    "category": "Specifications",
+                    "section": "Performance Data",
+                    "tooltip": null,
+                    "property_value_kind": "Single",
+                    "unit": "",
+                    "unit_code": "",
+                    "parameter_type": "I",
+                    "pset": "PostOccupancyEvaluationEnergyRecord",
+                    "id": 3083,
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "BuildingID": {
+                    "revit_data_type": "TEXT",
+                    "ifc_data_type": "IfcIdentifier",
+                    "namespace_uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/prop/BuildingID",
+                    "guid": "f5797b00-d1c4-11e1-8000-00215ad4efdf",
+                    "guid_source": "IFC",
+                    "title": "Building I D",
+                    "name": "BuildingID",
+                    "description": "A unique identifier assigned to a building. A temporary identifier is initially assigned at the time of making a planning application. This temporary identifier is changed to a permanent identifier when the building is registered into a statutory buildings and properties database.",
+                    "json_schema_extra": null,
+                    "category": "Undefined",
+                    "section": "Undefined",
+                    "tooltip": null,
+                    "property_value_kind": "Single",
+                    "unit": "",
+                    "unit_code": "",
+                    "parameter_type": "I",
+                    "pset": "EnergyRecord",
+                    "id": 1042,
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "TypeMark": {
+                    "enum": [
+                        "ED-1"
+                    ],
+                    "type": "string",
+                    "revit_data_type": "TEXT",
+                    "ifc_data_type": "IfcText",
+                    "namespace_uri": null,
+                    "guid": "95cba5f9-706b-49e1-9100-c423f2c1f6f5",
+                    "guid_source": "MXF",
+                    "title": "Type Mark",
+                    "name": "TypeMark",
+                    "description": "",
+                    "json_schema_extra": {
+                        "autoui": "ipywidgets.Dropdown"
+                    },
+                    "category": "Undefined",
+                    "section": "Identity Data",
+                    "tooltip": null,
+                    "property_value_kind": "Single",
+                    "unit": "",
+                    "unit_code": "",
+                    "parameter_type": "I",
+                    "pset": "",
+                    "id": 0,
+                    "autoui": "ipywidgets.Dropdown"
+                },
+                "TypeSpecId": {
+                    "format": "default",
+                    "revit_data_type": "INTEGER",
+                    "ifc_data_type": "IfcInteger",
+                    "namespace_uri": null,
+                    "guid": "f5bdea0b-8648-43a6-b85a-5cc443d86e8e",
+                    "guid_source": "MXF",
+                    "title": "Type Spec Id",
+                    "name": "TypeSpecId",
+                    "description": "",
+                    "json_schema_extra": null,
+                    "category": "Undefined",
+                    "section": "Undefined",
+                    "tooltip": null,
+                    "property_value_kind": "Single",
+                    "unit": "",
+                    "unit_code": "",
+                    "parameter_type": "I",
+                    "pset": "",
+                    "id": 0,
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "Id": {
+                    "format": "default",
+                    "revit_data_type": "INTEGER",
+                    "ifc_data_type": "IfcInteger",
+                    "namespace_uri": null,
+                    "guid": "958e6995-9f04-49d3-ba03-738b6bd66fd0",
+                    "guid_source": "MXF",
+                    "title": "Id",
+                    "name": "Id",
+                    "description": "",
+                    "json_schema_extra": null,
+                    "category": "Undefined",
+                    "section": "Undefined",
+                    "tooltip": null,
+                    "property_value_kind": "Single",
+                    "unit": "",
+                    "unit_code": "",
+                    "parameter_type": "I",
+                    "pset": "",
+                    "id": 0,
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "id": 833
+        }
+    }
+}


### PR DESCRIPTION
fixes issue where the grid would get cleared if the `order` trait was being used to filter as it wasn't mapping the names to the titles