### PR TITLE
🐛 EditGrid: Pass kwargs to parent class

### DIFF
--- a/src/ipyautoui/custom/buttonbars.py
+++ b/src/ipyautoui/custom/buttonbars.py
@@ -356,7 +356,7 @@ class CrudButtonBar(w.VBox):
     fn_backward = tr.Callable(default_value=lambda: print("backward"))
     fn_support = tr.Callable(default_value=lambda: print("support"))
     fn_reload = tr.Callable(default_value=None, allow_none=True)
-    show_support = tr.Bool(default_value=False)
+    show_support = tr.Bool(default_value=True)
 
     @tr.observe("show_support")
     def _observe_show_support(self, change):

--- a/src/ipyautoui/custom/buttonbars.py
+++ b/src/ipyautoui/custom/buttonbars.py
@@ -320,7 +320,6 @@ DEFAULT_BUTTONBAR_CONFIG = CrudView(
     ),
     support=CrudOptions(
         **dict(HELP_BUTTON_KWARGS)
-        | dict(layout=dict(display="None"))
         | dict(
             tooltip="help - click to show description of all buttons in the toolbar",
             tooltip_clicked="hide help dialogue",

--- a/src/ipyautoui/custom/editgrid.py
+++ b/src/ipyautoui/custom/editgrid.py
@@ -336,6 +336,8 @@ class EditGrid(w.VBox, TitleDescription):
         self._init_form()
         self._init_row_controls()
         self._init_controls()
+        # NOTE: setting kwargs here and in _init_autogrid may cause unwanted behaviour
+        # PR: https://github.com/maxfordham/ipyautoui/pull/351
         super().__init__(**kwargs)
         self.warn_on_delete = warn_on_delete
         # self.show_copy_dialogue = show_copy_dialogue
@@ -891,5 +893,3 @@ if __name__ == "__main__":
 
 if __name__ == "__main__":
     editgrid.transposed = True
-
-

--- a/src/ipyautoui/custom/editgrid.py
+++ b/src/ipyautoui/custom/editgrid.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.6
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -336,7 +336,7 @@ class EditGrid(w.VBox, TitleDescription):
         self._init_form()
         self._init_row_controls()
         self._init_controls()
-        super().__init__()
+        super().__init__(**kwargs)
         self.warn_on_delete = warn_on_delete
         # self.show_copy_dialogue = show_copy_dialogue
         self.show_copy_dialogue = False
@@ -738,7 +738,7 @@ if __name__ == "__main__":
             ),
         )
 
-    editgrid._update_from_schema(TestDataFrame, value=[{"string": "Test"}] * 10)
+    editgrid.update_from_schema(TestDataFrame, value=[{"string": "Test"}] * 10)
 
 if __name__ == "__main__":
     from pydantic import RootModel
@@ -891,3 +891,5 @@ if __name__ == "__main__":
 
 if __name__ == "__main__":
     editgrid.transposed = True
+
+


### PR DESCRIPTION
This is required for any traits that are defined.

Also resolved issue with the support button used in `EditGrid`.