### PR TITLE
🐛FIX: `_set_children` -> `set_children_editgrid` to prevent name overides on inheritance

### DIFF
--- a/src/ipyautoui/custom/editgrid.py
+++ b/src/ipyautoui/custom/editgrid.py
@@ -8,7 +8,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.6
+#       jupytext_version: 1.17.2
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -346,7 +346,7 @@ class EditGrid(w.VBox, TitleDescription):
         # self.show_copy_dialogue = show_copy_dialogue
         self.show_copy_dialogue = False
         # ^ TODO: delete this when that functionality is added
-        self._set_children()
+        self._set_children_editgrid()
         self._set_datahandler(datahandler=datahandler)
         self._update_value_from_grid()
 
@@ -372,7 +372,7 @@ class EditGrid(w.VBox, TitleDescription):
         )
         self._init_row_controls()
         self._init_controls()
-        self._set_children()
+        self._set_children_editgrid()
         self._set_datahandler(datahandler=datahandler)
 
     def _init_autogrid(
@@ -453,7 +453,7 @@ class EditGrid(w.VBox, TitleDescription):
         if self.datahandler is not None:
             self.buttonbar_grid.fn_reload = self._reload_datahandler
 
-    def _set_children(self):
+    def _set_children_editgrid(self):
         self.vbx_widget.children = [self.buttonbar_grid, self.stk_crud, self.grid]
         self.stk_crud.children = [
             self.ui_add,


### PR DESCRIPTION
fixes AutoUi callable for EditGrid objects. 
therefore fixes EditGrid examples in the demo.

TODO: still need to fix the nested nullable object example